### PR TITLE
design(m3): brand design system — tokens, decoratives, motion

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [main, next]
   pull_request:
-    branches: [main, next]
 
 # TODO: refactor to call the reusable workflow from bravobyte-platform once published.
 # uses: BravoByte-org/bravobyte-platform/.github/workflows/ci-web.yml@<sha>

--- a/spec.md
+++ b/spec.md
@@ -2,7 +2,7 @@
 
 > **Owner:** BravoByteLLC for Dolce Vita CT
 > **Domain:** https://dolcevitact.com
-> **Status:** M0 Foundation — scaffold complete, content pipeline pending
+> **Status:** M3 Design system — tokens + decoratives in review (PR #16); M0/M1 PRs open; Directus + Vercel handoffs pending
 > **Last Updated:** April 21, 2026
 
 This is the single source of truth for what `dolcevitact-web` is, why it exists,
@@ -79,9 +79,9 @@ The homepage is a single Directus `pages` row composed of M2A blocks:
 | --- | ------------------------ | ----------- | ------------------------------------------------------------------ | ---------------------------------------------- |
 | M-1 | GitHub workspace         | done        | —                                                                  | Repo, labels, templates, board, epics, stories |
 | M0  | Foundation               | in progress | [#1](https://github.com/BravoByte-org/dolcevitact-web/milestone/1) | Scaffold + Directus site row + Vercel + DNS    |
-| M1  | Shared content contracts | planned     | [#2](https://github.com/BravoByte-org/dolcevitact-web/milestone/2) | `@bravobyte/types` extension                   |
-| M2  | Directus schema          | planned     | [#3](https://github.com/BravoByte-org/dolcevitact-web/milestone/3) | Collections + permissions + seed               |
-| M3  | Design system            | planned     | [#4](https://github.com/BravoByte-org/dolcevitact-web/milestone/4) | Tokens, typography, grain                      |
+| M1  | Shared content contracts | in review   | [#2](https://github.com/BravoByte-org/dolcevitact-web/milestone/2) | `@bravobyte/types` extension (types PR #2)     |
+| M2  | Directus schema          | blocked     | [#3](https://github.com/BravoByte-org/dolcevitact-web/milestone/3) | Needs Directus admin handoff                   |
+| M3  | Design system            | in review   | [#4](https://github.com/BravoByte-org/dolcevitact-web/milestone/4) | Tokens, decoratives, motion (PR #16, stacked)  |
 | M4  | Sections                 | planned     | [#5](https://github.com/BravoByte-org/dolcevitact-web/milestone/5) | 9 sections + nav + footer                      |
 | M5  | RSVP                     | planned     | [#6](https://github.com/BravoByte-org/dolcevitact-web/milestone/6) | Form action + Resend                           |
 | M6  | Launch                   | planned     | [#7](https://github.com/BravoByte-org/dolcevitact-web/milestone/7) | SEO, a11y, deploy                              |

--- a/src/app.css
+++ b/src/app.css
@@ -1,6 +1,7 @@
 @import 'tailwindcss';
 @import './lib/styles/tokens.css';
 @import './lib/styles/fonts.css';
+@import './lib/styles/motion.css';
 
 /* em-based custom-media for browser zoom + user font-size accessibility. */
 @custom-media --sm (min-width: 40em);
@@ -8,22 +9,47 @@
 @custom-media --lg (min-width: 64em);
 @custom-media --xl (min-width: 80em);
 
-/* Map design tokens into Tailwind v4 theme so utilities like bg-ivory, text-terracotta, font-display work. */
+/* Map design tokens into Tailwind v4 theme so utilities like bg-ivory,
+   text-terracotta, font-display, shadow-soft work. */
 @theme {
 	--color-ivory: var(--dv-color-ivory);
+	--color-ivory-deep: var(--dv-color-ivory-deep);
+	--color-ivory-shadow: var(--dv-color-ivory-shadow);
 	--color-terracotta: var(--dv-color-terracotta);
+	--color-terracotta-soft: var(--dv-color-terracotta-soft);
+	--color-terracotta-deep: var(--dv-color-terracotta-deep);
 	--color-sage: var(--dv-color-sage);
+	--color-sage-soft: var(--dv-color-sage-soft);
+	--color-sage-deep: var(--dv-color-sage-deep);
 	--color-taupe: var(--dv-color-taupe);
 	--color-gold: var(--dv-color-gold);
+	--color-gold-deep: var(--dv-color-gold-deep);
 	--color-charcoal: var(--dv-color-charcoal);
 	--color-charcoal-soft: var(--dv-color-charcoal-soft);
+	--color-charcoal-mute: var(--dv-color-charcoal-mute);
 
 	--font-display: var(--dv-font-display);
 	--font-script: var(--dv-font-script);
 	--font-sans: var(--dv-font-sans);
 
-	--radius-card: 0.5rem;
-	--radius-pill: 9999px;
+	--text-eyebrow: var(--dv-text-eyebrow);
+	--text-body: var(--dv-text-body);
+	--text-lede: var(--dv-text-lede);
+	--text-h4: var(--dv-text-h4);
+	--text-h3: var(--dv-text-h3);
+	--text-h2: var(--dv-text-h2);
+	--text-h1: var(--dv-text-h1);
+	--text-script: var(--dv-text-script);
+
+	--radius-sm: var(--dv-radius-sm);
+	--radius-md: var(--dv-radius-md);
+	--radius-lg: var(--dv-radius-lg);
+
+	--shadow-soft: var(--dv-shadow-soft);
+	--shadow-card: var(--dv-shadow-card);
+	--shadow-lift: var(--dv-shadow-lift);
+
+	--ease-soft: var(--dv-ease-soft);
 }
 
 @media (prefers-reduced-motion: reduce) {
@@ -43,7 +69,54 @@ html {
 }
 
 body {
-	font-family: var(--font-sans);
+	font-family: var(--dv-font-sans);
+	font-size: var(--dv-text-body);
+	line-height: var(--dv-leading-body);
+	color: var(--dv-color-charcoal);
+	background-color: var(--dv-color-ivory);
 	-webkit-font-smoothing: antialiased;
 	-moz-osx-font-smoothing: grayscale;
+}
+
+/* Eyebrow — small, wide-tracked, uppercase. Used to label sections. */
+.dv-eyebrow {
+	font-family: var(--dv-font-sans);
+	font-size: var(--dv-text-eyebrow);
+	font-weight: 500;
+	letter-spacing: var(--dv-tracking-eyebrow);
+	text-transform: uppercase;
+	color: var(--dv-color-charcoal-mute);
+}
+
+/* Display headings */
+.dv-h1 {
+	font-family: var(--dv-font-display);
+	font-size: var(--dv-text-h1);
+	font-weight: 500;
+	line-height: var(--dv-leading-tight);
+	letter-spacing: -0.01em;
+	color: var(--dv-color-charcoal);
+}
+
+.dv-h2 {
+	font-family: var(--dv-font-display);
+	font-size: var(--dv-text-h2);
+	font-weight: 500;
+	line-height: var(--dv-leading-snug);
+	letter-spacing: -0.005em;
+	color: var(--dv-color-charcoal);
+}
+
+.dv-script {
+	font-family: var(--dv-font-script);
+	font-size: var(--dv-text-script);
+	line-height: 1;
+	color: var(--dv-color-gold);
+}
+
+/* Lede paragraph — slightly larger and lighter than body */
+.dv-lede {
+	font-size: var(--dv-text-lede);
+	color: var(--dv-color-charcoal-soft);
+	line-height: var(--dv-leading-body);
 }

--- a/src/lib/components/decor/GoldRule.svelte
+++ b/src/lib/components/decor/GoldRule.svelte
@@ -1,0 +1,59 @@
+<script lang="ts">
+	/**
+	 * GoldRule — a thin gold divider with a small lozenge in the centre.
+	 * Used between sections, beneath eyebrows, and to terminate quoted blocks.
+	 *
+	 * Variants:
+	 *   - 'sm' (default): 4rem wide; for in-section emphasis under eyebrows
+	 *   - 'md': 8rem; for header / footer separators
+	 *   - 'lg': 14rem; for between major sections
+	 */
+	type Size = 'sm' | 'md' | 'lg';
+
+	type Props = {
+		size?: Size;
+		class?: string;
+	};
+
+	let { size = 'sm', class: extraClass = '' }: Props = $props();
+
+	const widths: Record<Size, string> = {
+		sm: 'w-16',
+		md: 'w-32',
+		lg: 'w-56'
+	};
+</script>
+
+<div
+	class="dv-gold-rule mx-auto flex items-center gap-2 {widths[size]} {extraClass}"
+	aria-hidden="true"
+>
+	<span class="dv-gold-rule__line"></span>
+	<span class="dv-gold-rule__diamond"></span>
+	<span class="dv-gold-rule__line"></span>
+</div>
+
+<style>
+	.dv-gold-rule__line {
+		flex: 1 1 auto;
+		height: 1px;
+		background: linear-gradient(
+			to right,
+			transparent 0%,
+			var(--dv-color-gold) 40%,
+			var(--dv-color-gold) 60%,
+			transparent 100%
+		);
+		transform-origin: center;
+		animation: dv-rule-grow var(--dv-duration-slow) var(--dv-ease-soft) both;
+	}
+
+	.dv-gold-rule__diamond {
+		width: 6px;
+		height: 6px;
+		flex: 0 0 auto;
+		background-color: var(--dv-color-gold);
+		transform: rotate(45deg);
+		opacity: 0.85;
+	}
+</style>

--- a/src/lib/components/decor/Grain.svelte
+++ b/src/lib/components/decor/Grain.svelte
@@ -1,0 +1,43 @@
+<script lang="ts">
+	/**
+	 * Grain — a paper-texture noise overlay applied via SVG `feTurbulence`.
+	 * Renders as a fixed full-screen layer behind the page content (when
+	 * mounted at the layout level) so the entire site sits on a subtly
+	 * textured ivory paper rather than a flat solid colour.
+	 *
+	 * Defaults to a low-intensity layer suitable for body backgrounds.
+	 * Tune `opacity` for hero-emphasis variants.
+	 */
+	type Props = {
+		opacity?: number;
+		class?: string;
+	};
+
+	let { opacity = 0.06, class: extraClass = '' }: Props = $props();
+</script>
+
+<div class="dv-grain {extraClass}" style:opacity aria-hidden="true">
+	<svg width="100%" height="100%" xmlns="http://www.w3.org/2000/svg">
+		<filter id="dv-grain-noise">
+			<feTurbulence type="fractalNoise" baseFrequency="0.85" numOctaves="2" stitchTiles="stitch" />
+			<feColorMatrix
+				type="matrix"
+				values="0 0 0 0 0.17
+				        0 0 0 0 0.16
+				        0 0 0 0 0.15
+				        0 0 0 0.85 0"
+			/>
+		</filter>
+		<rect width="100%" height="100%" filter="url(#dv-grain-noise)" />
+	</svg>
+</div>
+
+<style>
+	.dv-grain {
+		position: fixed;
+		inset: 0;
+		pointer-events: none;
+		z-index: 0;
+		mix-blend-mode: multiply;
+	}
+</style>

--- a/src/lib/components/decor/OliveBranch.svelte
+++ b/src/lib/components/decor/OliveBranch.svelte
@@ -1,0 +1,69 @@
+<script lang="ts">
+	/**
+	 * OliveBranch — a hand-drawn-feeling SVG of an olive sprig.
+	 * Default colour is muted sage; pass `tone="gold"` for the rare gold
+	 * accent variant used in the hero. The component is purely decorative
+	 * and announces itself as such to assistive tech.
+	 */
+	type Tone = 'sage' | 'gold';
+
+	type Props = {
+		tone?: Tone;
+		flip?: boolean;
+		class?: string;
+	};
+
+	let { tone = 'sage', flip = false, class: extraClass = '' }: Props = $props();
+
+	const stroke = $derived(
+		tone === 'gold' ? 'var(--dv-color-gold-deep)' : 'var(--dv-color-sage-deep)'
+	);
+	const leaf = $derived(tone === 'gold' ? 'var(--dv-color-gold)' : 'var(--dv-color-sage)');
+	const berry = $derived(
+		tone === 'gold' ? 'var(--dv-color-terracotta-deep)' : 'var(--dv-color-charcoal-soft)'
+	);
+</script>
+
+<svg
+	viewBox="0 0 200 80"
+	xmlns="http://www.w3.org/2000/svg"
+	role="presentation"
+	aria-hidden="true"
+	class="dv-olive {extraClass}"
+	style:transform={flip ? 'scaleX(-1)' : undefined}
+>
+	<g fill="none" {stroke} stroke-width="1.2" stroke-linecap="round">
+		<path d="M10 40 C 60 38, 130 42, 190 40" />
+		<path d="M55 40 C 50 30, 45 24, 38 22" />
+		<path d="M75 40 C 72 50, 70 56, 64 60" />
+		<path d="M95 40 C 92 30, 90 24, 84 21" />
+		<path d="M115 40 C 112 50, 110 56, 104 59" />
+		<path d="M135 40 C 132 31, 130 25, 124 22" />
+		<path d="M155 40 C 152 50, 150 55, 145 58" />
+	</g>
+	<g fill={leaf} {stroke} stroke-width="0.6">
+		<ellipse cx="36" cy="20" rx="8" ry="3" transform="rotate(-25 36 20)" />
+		<ellipse cx="63" cy="61" rx="8" ry="3" transform="rotate(28 63 61)" />
+		<ellipse cx="82" cy="19" rx="8" ry="3" transform="rotate(-25 82 19)" />
+		<ellipse cx="103" cy="60" rx="8" ry="3" transform="rotate(28 103 60)" />
+		<ellipse cx="122" cy="20" rx="8" ry="3" transform="rotate(-25 122 20)" />
+		<ellipse cx="144" cy="59" rx="8" ry="3" transform="rotate(28 144 59)" />
+	</g>
+	<g fill={berry}>
+		<circle cx="44" cy="25" r="1.5" />
+		<circle cx="74" cy="55" r="1.5" />
+		<circle cx="90" cy="24" r="1.5" />
+		<circle cx="115" cy="54" r="1.5" />
+		<circle cx="130" cy="25" r="1.5" />
+		<circle cx="153" cy="53" r="1.5" />
+	</g>
+</svg>
+
+<style>
+	.dv-olive {
+		display: block;
+		width: 100%;
+		height: auto;
+		opacity: 0.85;
+	}
+</style>

--- a/src/lib/styles/fonts.css
+++ b/src/lib/styles/fonts.css
@@ -1,7 +1,14 @@
 /*
- * Webfont registration.
- * Self-hosted under /static/fonts in M3. For the scaffold, we load from
- * Google Fonts to unblock visual iteration; M3 swaps to subset, self-hosted
- * woff2 with rel=preload for performance.
+ * Webfont registration
+ * --------------------------------------------------------------
+ * Fonts are loaded via <link rel="stylesheet"> in src/routes/+layout.svelte
+ * (with paired <link rel="preconnect"> hints) so that:
+ *   1. The CSS @import-must-come-first rule isn't violated when this file
+ *      is bundled with tokens / motion / Tailwind into a single stylesheet.
+ *   2. The browser starts the font fetch as soon as the HTML is parsed,
+ *      not after the main stylesheet downloads + parses.
+ *
+ * M6 (#12) swaps Google Fonts for self-hosted, subset woff2 with
+ * rel="preload" for the display + script faces (the only two used
+ * above the fold in the hero).
  */
-@import url('https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,400;0,500;0,600;1,400&family=Inter:wght@400;500;600&family=Tangerine:wght@400;700&display=swap');

--- a/src/lib/styles/motion.css
+++ b/src/lib/styles/motion.css
@@ -1,0 +1,43 @@
+/*
+ * Reusable motion primitives for editorial entrance + emphasis.
+ * Every keyframe is short and softly eased. The reduced-motion
+ * media query in app.css shortens transitions/animations to ~0,
+ * so consumers don't need to guard each call site individually.
+ */
+
+@keyframes dv-fade-rise {
+	from {
+		opacity: 0;
+		transform: translateY(0.75rem);
+	}
+	to {
+		opacity: 1;
+		transform: none;
+	}
+}
+
+@keyframes dv-fade-in {
+	from {
+		opacity: 0;
+	}
+	to {
+		opacity: 1;
+	}
+}
+
+@keyframes dv-rule-grow {
+	from {
+		transform: scaleX(0);
+	}
+	to {
+		transform: scaleX(1);
+	}
+}
+
+.dv-anim-rise {
+	animation: dv-fade-rise var(--dv-duration-slow) var(--dv-ease-soft) both;
+}
+
+.dv-anim-fade {
+	animation: dv-fade-in var(--dv-duration-base) var(--dv-ease-soft) both;
+}

--- a/src/lib/styles/tokens.css
+++ b/src/lib/styles/tokens.css
@@ -4,36 +4,78 @@
  * The brand palette is intentionally restrained: warm ivory paper,
  * earthy terracotta, muted sage, sand taupe, restrained gold accents,
  * and soft charcoal text. Every other surface should be a derivative
- * of these. Keep this file small.
+ * of these. Keep this file small and avoid hard-coded hex values
+ * elsewhere in the codebase.
  */
 
 :root {
-	/* Color */
+	/* ------------------------------------------------------------- */
+	/* Color                                                          */
+	/* ------------------------------------------------------------- */
 	--dv-color-ivory: #f6f1ec;
 	--dv-color-ivory-deep: #ede5db;
+	--dv-color-ivory-shadow: #e3d9cb;
 	--dv-color-terracotta: #b8694b;
 	--dv-color-terracotta-soft: #d99578;
+	--dv-color-terracotta-deep: #8f4d35;
 	--dv-color-sage: #8a9a7a;
 	--dv-color-sage-soft: #b6c2a8;
+	--dv-color-sage-deep: #5e6e51;
 	--dv-color-taupe: #b8a88f;
 	--dv-color-gold: #c9a46b;
+	--dv-color-gold-deep: #a98448;
 	--dv-color-charcoal: #2b2a28;
 	--dv-color-charcoal-soft: #5b5853;
+	--dv-color-charcoal-mute: #8a8680;
 
-	/* Typography */
+	/* ------------------------------------------------------------- */
+	/* Typography                                                     */
+	/* ------------------------------------------------------------- */
 	--dv-font-display: 'Cormorant Garamond', 'Playfair Display', Georgia, serif;
 	--dv-font-script: 'Tangerine', 'Allura', cursive;
 	--dv-font-sans:
 		'Inter', system-ui, -apple-system, 'Segoe UI', Roboto, 'Helvetica Neue', sans-serif;
 
-	/* Spacing scale (rem) — tight rhythm for editorial layout */
+	/* Editorial-feel fluid type scale */
+	--dv-text-eyebrow: 0.75rem; /* 12px */
+	--dv-text-body: 1.0625rem; /* 17px — slightly larger than default sans for editorial cadence */
+	--dv-text-lede: clamp(1.125rem, 0.9rem + 0.7vw, 1.375rem);
+	--dv-text-h4: clamp(1.25rem, 1rem + 0.8vw, 1.5rem);
+	--dv-text-h3: clamp(1.5rem, 1.1rem + 1.4vw, 2rem);
+	--dv-text-h2: clamp(2rem, 1.4rem + 2.4vw, 3rem);
+	--dv-text-h1: clamp(2.5rem, 1.6rem + 3.6vw, 4.5rem);
+	--dv-text-script: clamp(2rem, 1.4rem + 2.4vw, 3.25rem);
+
+	--dv-leading-tight: 1.1;
+	--dv-leading-snug: 1.25;
+	--dv-leading-body: 1.65;
+	--dv-tracking-eyebrow: 0.18em;
+
+	/* ------------------------------------------------------------- */
+	/* Spacing                                                        */
+	/* ------------------------------------------------------------- */
 	--dv-space-section: clamp(4rem, 8vw, 8rem);
 	--dv-space-block: clamp(1.5rem, 3vw, 3rem);
 
-	/* Radii — subtle, never playful */
+	/* ------------------------------------------------------------- */
+	/* Radii — subtle, never playful                                  */
+	/* ------------------------------------------------------------- */
 	--dv-radius-sm: 4px;
 	--dv-radius-md: 8px;
+	--dv-radius-lg: 12px;
 
-	/* Shadows — only where useful */
+	/* ------------------------------------------------------------- */
+	/* Shadows — only where useful                                    */
+	/* ------------------------------------------------------------- */
 	--dv-shadow-soft: 0 12px 32px -16px rgb(43 42 40 / 0.18);
+	--dv-shadow-card: 0 18px 40px -22px rgb(43 42 40 / 0.22);
+	--dv-shadow-lift: 0 1px 0 0 rgb(43 42 40 / 0.04), 0 24px 56px -28px rgb(43 42 40 / 0.28);
+
+	/* ------------------------------------------------------------- */
+	/* Motion                                                         */
+	/* ------------------------------------------------------------- */
+	--dv-ease-soft: cubic-bezier(0.32, 0.08, 0.24, 1);
+	--dv-duration-fast: 180ms;
+	--dv-duration-base: 320ms;
+	--dv-duration-slow: 600ms;
 }

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import '../app.css';
+	import Grain from '$components/decor/Grain.svelte';
 
 	let { children } = $props();
 </script>
@@ -19,6 +20,16 @@
 	/>
 	<meta property="og:url" content="https://dolcevitact.com/" />
 	<meta property="og:locale" content="en_US" />
+	<link rel="preconnect" href="https://fonts.googleapis.com" />
+	<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="anonymous" />
+	<link
+		rel="stylesheet"
+		href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,400;0,500;0,600;1,400&family=Inter:wght@400;500;600&family=Tangerine:wght@400;700&display=swap"
+	/>
 </svelte:head>
 
-{@render children()}
+<Grain />
+
+<div class="relative z-10">
+	{@render children()}
+</div>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,24 +1,43 @@
 <script lang="ts">
-	// Placeholder homepage. Sections are wired in M4 (#9, #10) and content comes
-	// from Directus via the site-scoped query. Keeping this minimal so M0 ships
-	// a clean foundation.
+	import GoldRule from '$components/decor/GoldRule.svelte';
+	import OliveBranch from '$components/decor/OliveBranch.svelte';
+
+	// Placeholder homepage that exercises the M3 design system.
+	// Replaced in M4 (#9, #10) once Directus content + sticky nav land.
 </script>
 
 <main
-	class="mx-auto flex min-h-screen max-w-3xl flex-col items-center justify-center px-6 text-center"
+	class="dv-anim-fade mx-auto flex min-h-screen max-w-3xl flex-col items-center justify-center px-6 py-24 text-center"
 >
-	<p class="font-script text-gold text-5xl leading-none">Dolce Vita CT</p>
-	<h1 class="font-display text-charcoal mt-6 text-4xl sm:text-6xl">
-		Coming soon to <span class="text-terracotta">Stamford, Connecticut</span>
+	<p class="dv-eyebrow">Stamford · Connecticut</p>
+
+	<div class="mt-8 w-44 sm:w-56">
+		<OliveBranch tone="sage" />
+	</div>
+
+	<p class="dv-script mt-6">Dolce Vita CT</p>
+
+	<h1 class="dv-h1 dv-anim-rise mt-4 max-w-2xl">
+		An Italian-inspired moment for <em class="font-display text-terracotta italic"
+			>mama e bambino</em
+		>
 	</h1>
-	<p class="text-charcoal-soft mx-auto mt-6 max-w-xl text-lg">
-		A premium Italian-inspired experience for moms and babies. Reservations open soon for our first
-		Dolce Vita Baby Circle.
+
+	<div class="mt-8">
+		<GoldRule size="md" />
+	</div>
+
+	<p class="dv-lede dv-anim-rise mx-auto mt-8 max-w-xl text-balance">
+		Reservations open soon for the first <strong class="font-medium">Dolce Vita Baby Circle</strong> —
+		a warm, refined class for moms and babies, led by a native Italian speaker, teacher, and mom.
 	</p>
+
 	<a
-		href="mailto:hello@dolcevitact.com"
-		class="bg-terracotta hover:bg-terracotta/90 text-ivory mt-10 inline-flex items-center justify-center rounded-md px-6 py-3 text-sm font-medium tracking-wide uppercase transition-colors"
+		href="mailto:hello@dolcevitact.com?subject=Dolce%20Vita%20CT%20—%20early%20list"
+		class="bg-terracotta hover:bg-terracotta-deep text-ivory shadow-soft mt-12 inline-flex items-center justify-center rounded-md px-7 py-3.5 text-sm font-medium tracking-[0.18em] uppercase transition-colors duration-300 ease-[var(--ease-soft)]"
 	>
 		Be the first to know
 	</a>
+
+	<p class="text-charcoal-mute mt-16 text-xs tracking-widest uppercase">Coming spring · Stamford</p>
 </main>


### PR DESCRIPTION
## Summary

Builds out the Dolce Vita CT visual language so M4 (#9, #10) can compose
sections against a stable design system rather than inventing one per
component.

- **Tokens** (`src/lib/styles/tokens.css`): full ivory / terracotta / sage / taupe / gold / charcoal ramps with deep + soft variants, editorial fluid type scale (eyebrow → h1 + script), leading/tracking, shadow + motion tokens.
- **Tailwind v4 mapping** (`src/app.css`): every token surfaces as a utility (`text-h2`, `font-display`, `color-terracotta-deep`, `shadow-soft`, `ease-soft`, …) plus semantic typography classes `dv-eyebrow / dv-h1 / dv-h2 / dv-script / dv-lede`.
- **Motion** (`src/lib/styles/motion.css`): `dv-fade-rise`, `dv-fade-in`, `dv-rule-grow` keyframes + `.dv-anim-*` utilities. The reduced-motion query in `app.css` continues to dampen all animation globally.
- **Decoratives** (`src/lib/components/decor/`):
  - `GoldRule.svelte` — gradient-into-diamond divider (sm/md/lg)
  - `OliveBranch.svelte` — inline SVG sprig with sage/gold tones + `flip` (berry colour `\$derived` from tone)
  - `Grain.svelte` — fixed full-screen `feTurbulence` ivory paper texture, `mix-blend-mode: multiply`
- **Fonts**: switched from CSS `@import` (which violated the @import-must-come-first rule once tokens/motion bundled before it) to `<link rel="stylesheet">` + `preconnect` in `<svelte:head>`. M6 (#12) swaps to subset, self-hosted woff2 with `rel=preload`.
- **Homepage placeholder** (`src/routes/+page.svelte`): now exercises the full system (eyebrow → olive branch → script wordmark → h1 with terracotta italic accent → gold rule → lede → CTA) so we have a real visual baseline before M4.

## Stacked PR

This branch is stacked on `chore/m0-foundation` (PR #15). Once that
squash-merges to \`next\`, this PR's base will auto-update and it can
also squash-merge in turn — per the repo's stacked-PR policy.

## Test plan

- [x] \`pnpm run format\` clean
- [x] \`pnpm run lint\` clean
- [x] \`pnpm run check\` — 0 errors, 0 warnings
- [x] \`pnpm run build\` — Vercel adapter build succeeds
- [x] Dev server boots clean (no PostCSS \`@import-must-come-first\` warning)
- [x] \`/\` returns HTTP 200 and renders the placeholder hero
- [ ] Reviewer to scan homepage in dev (\`pnpm run dev\`) and confirm:
  - olive sprig + script wordmark + gold rule render
  - paper grain visible behind content
  - terracotta CTA, type scale feels editorial / premium

Refs #1
Closes #8

Made with [Cursor](https://cursor.com)