### PR TITLE
feat(m4b): sticky editorial nav, mobile drawer, site footer + nav seed

### DIFF
--- a/.docs/architecture/m4-sections-plan.md
+++ b/.docs/architecture/m4-sections-plan.md
@@ -1,0 +1,202 @@
+# M4 — Sections implementation plan
+
+> **Status:** active, in progress as of April 21, 2026
+> **Milestone:** [M4](https://github.com/BravoByte-org/dolcevitact-web/milestone/5)
+> **Precedes:** M5 (RSVP form action + Resend)
+> **Inherits:** M2 Directus schema (`.docs/operations/m2-verification.md`) + M3 design system (tokens, decoratives, motion)
+
+M4 turns the 9 M2 page blocks into real Svelte components, registers them
+in a `BlockRenderer`, and replaces the layout's temporary header ribbon
+with an editorial sticky nav + mobile drawer. This document is the
+architecture + story breakdown; implementation will be split across
+dedicated stories / PRs per [`bravobyte-ai/git-history.md`](../../../bravobyte-ai/rules/git-history.md)
+(one story per PR).
+
+## 1. Scope
+
+### In
+
+| Deliverable                  | Story | Issue |
+| ---------------------------- | ----- | ----- |
+| `$components/blocks/types.ts` + `BlockRenderer` shell                    | M4a-1 | [#10](https://github.com/BravoByte-org/dolcevitact-web/issues/10) |
+| Six adapted shared-candidate blocks (hero, card_group, timeline, team, rich_text, cta/image_gallery if needed) | M4a-2 | " |
+| Three Dolce-Vita-first blocks (`block_event_details`, `block_rsvp_form` shell, `block_faq` + items)          | M4a-3 | " |
+| Editorial sticky nav + mobile drawer (`SiteNav` + `NavDrawer`), replaces the temp ribbon                      | M4b   | [#9](https://github.com/BravoByte-org/dolcevitact-web/issues/9)  |
+| Footer polish (keep current layout footer, tidy copy + socials if any)                                         | M4b   | [#9](https://github.com/BravoByte-org/dolcevitact-web/issues/9)  |
+
+### Out (explicitly deferred)
+
+| Item | Where it lands |
+| ---- | -------------- |
+| `block_rsvp_form` submit action (anonymous `POST /items/rsvp_submissions` → Resend notification) | M5 ([#11](https://github.com/BravoByte-org/dolcevitact-web/issues/11)) |
+| Image optimization (`@sveltejs/enhanced-img`), OG images, JSON-LD     | M6 ([#12](https://github.com/BravoByte-org/dolcevitact-web/issues/12)) |
+| Section entrance animations beyond what `$styles/motion.css` already provides | Captured in M6 polish pass |
+| Italian translations on CMS fields / UI strings                        | Parked (spec §7 — English-only v1)  |
+
+## 2. Component architecture
+
+### 2.1 `BlockRenderer` (mirror of Starway's pattern)
+
+Starway's `src/lib/components/blocks/BlockRenderer.svelte` is the
+canonical shape to inherit: a `componentMap` indexed by Directus
+collection name, iterated with keyed `{#each}` so Svelte can reuse DOM
+across HMR hops. Dolce Vita extends the map with the three DV-first
+collections:
+
+```svelte
+<script lang="ts">
+  import HeroBlock from './HeroBlock.svelte';
+  import RichTextBlock from './RichTextBlock.svelte';
+  import CardGroupBlock from './CardGroupBlock.svelte';
+  import TimelineBlock from './TimelineBlock.svelte';
+  import TeamBlock from './TeamBlock.svelte';
+  // DV-first
+  import EventDetailsBlock from './EventDetailsBlock.svelte';
+  import RsvpFormBlock from './RsvpFormBlock.svelte';
+  import FaqBlock from './FaqBlock.svelte';
+
+  import type { Block } from './types';
+  let { blocks = [] }: { blocks: Block[] } = $props();
+
+  const componentMap = {
+    block_hero: HeroBlock,
+    block_rich_text: RichTextBlock,
+    block_card_group: CardGroupBlock,
+    block_timeline: TimelineBlock,
+    block_team: TeamBlock,
+    block_event_details: EventDetailsBlock,
+    block_rsvp_form: RsvpFormBlock,
+    block_faq: FaqBlock,
+  } as const;
+</script>
+
+{#each blocks as block, i (`${block.collection}-${block.item.id ?? i}`)}
+  {@const Component = componentMap[block.collection as keyof typeof componentMap]}
+  {#if Component}<Component data={block.item as never} />{/if}
+{/each}
+```
+
+`types.ts` already exists (imported by `+page.svelte`); only needs a
+union of the 8 block item shapes from `@bravobyte/types` once M1 lands.
+Until then, keep the `Block = { collection: string; item: Record<string, unknown> }` shape and narrow inside each component — same pattern Starway uses today.
+
+### 2.2 Per-block components (directory: `src/lib/components/blocks/`)
+
+| File                    | Directus collection     | Starway origin? | Brand adaptations required                                                     |
+| ----------------------- | ----------------------- | --------------- | ------------------------------------------------------------------------------ |
+| `HeroBlock.svelte`      | `block_hero`            | ✓               | Replace utility color + type scales with DV tokens (Cormorant display + terracotta CTA); adopt `Grain` + `GoldRule` decoratives |
+| `RichTextBlock.svelte`  | `block_rich_text`       | ✓               | Scoped prose styles using `--dv-color-charcoal` / serif body, `OliveBranch` flourish at top if `variant === 'editorial'` |
+| `CardGroupBlock.svelte` | `block_card_group`      | ✓               | Strip trucking-specific hover effects; keep image-backed variant flag; use ivory/terracotta/sage trio |
+| `TimelineBlock.svelte`  | `block_timeline`        | ✓               | Replace Starway vertical-rule with DV `GoldRule` dividers; smaller year labels in script font |
+| `TeamBlock.svelte`      | `block_team`            | ✓               | Single-founder-optimized layout (most DV usage is n=1); bio reads as editorial paragraph, not Starway's card grid |
+| `EventDetailsBlock.svelte`   | `block_event_details` | ✗ (NEW) | Structured card: eyebrow, date/time/city stack, location note, CTA pill. Anchor via `cta_anchor` to `#rsvp`. |
+| `RsvpFormBlock.svelte`       | `block_rsvp_form`    | ✗ (NEW) | M4: renders the shell (heading, copy, fields, consent, success/error slots). M5: hooks `enhance` to the `/reserve` form action. No network I/O this milestone. |
+| `FaqBlock.svelte`            | `block_faq`          | ✗ (NEW) | Accordion pattern. Wraps child `block_faq_items` as `<details>`/`<summary>` for progressive-enhancement-first a11y. |
+
+For the 5 Starway-origin blocks, the work is **scoped CSS replacement**,
+not structural rewrite — the markup, prop shapes, data flow, and M2A
+resolution are all compatible. That's the payoff of the shared schema.
+
+### 2.3 Navigation (M4b)
+
+Replace the placeholder header ribbon with:
+
+- `SiteNav.svelte` — sticky, 64–72px tall desktop, loses its border on scroll to blend into the hero.
+  - Desktop (≥ 48em): horizontal link list (sections of the homepage as anchor links: `#about`, `#experience`, `#event`, `#rsvp`, `#faq`).
+  - Mobile (< 48em): `HamburgerButton.svelte` → toggles `NavDrawer.svelte`.
+- `NavDrawer.svelte` — off-canvas drawer (slides in from the right), `aria-modal`, focus-trapped, `Esc`-to-close, body-scroll-lock while open.
+- Inherit Starway's breakpoint mixin pattern (`em`-based, BEM class naming). **Direct import from Starway is not permitted** (Rule Zero: repo-local first). Copy the `$styles/breakpoints.css` file shape; extract into `bravobyte-frontend-core` after a third client needs it.
+
+### 2.4 Footer (M4b)
+
+Keep the current `+layout.svelte` footer structurally; only refresh copy
+to reference `reserve` + `hello@dolcevitact.com`. A proper `SiteFooter.svelte`
+component extraction can wait until the layout grows past ~3 blocks.
+
+## 3. Directory & naming
+
+```
+src/lib/components/
+  blocks/
+    BlockRenderer.svelte          — NEW (M4a-1)
+    types.ts                      — NEW (M4a-1)
+    HeroBlock.svelte              — NEW (M4a-2)
+    RichTextBlock.svelte          — NEW (M4a-2)
+    CardGroupBlock.svelte         — NEW (M4a-2)
+    TimelineBlock.svelte          — NEW (M4a-2)
+    TeamBlock.svelte              — NEW (M4a-2)
+    EventDetailsBlock.svelte      — NEW (M4a-3)
+    RsvpFormBlock.svelte          — NEW (M4a-3, shell only; M5 wires submit)
+    FaqBlock.svelte               — NEW (M4a-3)
+  navigation/
+    SiteNav.svelte                — NEW (M4b)
+    NavDrawer.svelte              — NEW (M4b)
+    HamburgerButton.svelte        — NEW (M4b)
+  decor/                          — unchanged (Grain, GoldRule, OliveBranch from M3)
+```
+
+All components use **scoped `<style>` with `@apply`** per
+[`bravobyte-ai/rules/tailwind-svelte.md`](../../../bravobyte-ai/rules/tailwind-svelte.md)
+and **nested BEM** per the Starway convention — no inline utility
+classes in the rendered markup.
+
+## 4. Reusability flags (for `bravobyte-frontend-core` extraction)
+
+Track each as a candidate. Extraction happens when a third client
+requests the same shape — until then, stay client-local per Rule Zero.
+
+| Candidate                                      | Why it's shared-candidate                                                                                     | Extraction trigger       |
+| ---------------------------------------------- | ------------------------------------------------------------------------------------------------------------- | ------------------------ |
+| `BlockRenderer` registry pattern               | Identical shape already in Starway; the registry map is the only delta per client                             | 3rd client adopts blocks |
+| `HeroBlock`, `RichTextBlock`, `CardGroupBlock`, `TimelineBlock`, `TeamBlock` contracts + **un-styled** primitives | Markup structure + prop shape are shared; only CSS is client-local                                   | 3rd client adopts blocks |
+| `NavDrawer` + `HamburgerButton` (body-scroll-lock, focus trap, `aria-modal`) | Pure a11y utilities, zero brand opinions                                                     | 2nd use (Starway also needs a drawer for complex nav — already partial) |
+| `breakpoints.css` em-based custom media set    | Identical values across clients; zero brand variance                                                          | 3rd client adopts Tailwind v4 |
+| `EventDetailsBlock` + `RsvpFormBlock` + `FaqBlock` + `FaqItem` shells | DV-first but the contracts are already shared in `@bravobyte/types` per M1; the unstyled shells are the next layer up | 2nd client needs event/RSVP/FAQ flows |
+
+## 5. Testing plan
+
+| Layer      | Coverage                                                                                                      | Tool                             |
+| ---------- | ------------------------------------------------------------------------------------------------------------- | -------------------------------- |
+| Component  | Each block renders with a minimal prop set; `BlockRenderer` skips unknown collections without throwing        | `vitest` + `@testing-library/svelte` |
+| Integration| `/` renders 9 blocks when Directus returns the seeded homepage; falls back to M3 placeholder on load failure  | `vitest` (SSR smoke)             |
+| A11y       | `NavDrawer` traps focus, restores on close, `Esc` closes; `FaqBlock` keyboard-navigable via `<details>`        | `@axe-core/playwright`           |
+| Visual     | No blank states, no utility-class leak, fonts load (Cormorant, Tangerine, Inter); Lighthouse ≥ 95 deferred to M6 | Playwright + manual preview      |
+
+Unit tests are optional for pure presentational components where the
+markup and prop shape are the full contract; SSR + a11y smoke tests are
+mandatory per M0's CI gate.
+
+## 6. Verification checklist
+
+Before marking M4 done in `spec.md`:
+
+- [ ] `pnpm check` clean (svelte-check + tsc)
+- [ ] `pnpm lint` clean (prettier + eslint)
+- [ ] `pnpm test` green (unit + SSR smoke)
+- [ ] `pnpm test:e2e` green for the homepage happy path
+- [ ] Preview deploy on Vercel renders the 9 blocks with correct fonts + palette + grain
+- [ ] `BlockRenderer` falls back silently when Directus returns an empty or partial block set (existing M3 fallback preserved)
+- [ ] SiteNav is keyboard-navigable, focus-visible outlines match design tokens, drawer passes axe-core
+- [ ] No inline Tailwind utility classes in any block component markup (per `tailwind-svelte.md`)
+- [ ] `.docs/operations/cms-triage.md` (to be added to DV) or `spec.md` lists any content TODOs left for the editor
+
+## 7. Story sequence (recommended PR order)
+
+1. **M4a-1 — "BlockRenderer shell + types"** (tiny, unblocks the rest)
+2. **M4a-2 — "Shared-candidate blocks (hero, rich_text, card_group, timeline, team) with DV branding"** — largest PR, paired with a `.docs/architecture/block-styling-guide.md` that records the CSS-token mapping
+3. **M4a-3 — "DV-first blocks (event_details, rsvp_form shell, faq)"** — no form submit yet
+4. **M4b — "Sticky editorial nav + mobile drawer + footer polish"**
+5. **M4 close — spec bump, re-audit display-metadata on the three DV-first collections (cross-reference [`bravobyte-ai/rules/directus-collection-display.md`](../../../bravobyte-ai/rules/directus-collection-display.md))**
+
+After M4 closes, M5 picks up the `/reserve` form action with the
+now-present (thanks to the M2 verification Public-policy fix) anonymous
+`POST /items/rsvp_submissions` permission.
+
+## 8. Cross-references
+
+- Spec (single source of truth): [`../../spec.md`](../../spec.md)
+- M2 runlog: [`../operations/m2-verification.md`](../operations/m2-verification.md)
+- Runbook (migration): [`../operations/directus-migration.md`](../operations/directus-migration.md)
+- ADR: [`../adrs/0001-dolce-vita-architecture.md`](../adrs/0001-dolce-vita-architecture.md)
+- Starway inheritance targets: `starwaytrasporti-web/src/lib/components/blocks/` (canonical BlockRenderer shape)
+- Shared rules: [`../../../bravobyte-ai/rules/tailwind-svelte.md`](../../../bravobyte-ai/rules/tailwind-svelte.md), [`../../../bravobyte-ai/rules/directus-collection-display.md`](../../../bravobyte-ai/rules/directus-collection-display.md), [`../../../bravobyte-ai/rules/directus-collection-permissions.md`](../../../bravobyte-ai/rules/directus-collection-permissions.md), [`../../../bravobyte-ai/rules/reusability.md`](../../../bravobyte-ai/rules/reusability.md)

--- a/.docs/architecture/m4-sections-plan.md
+++ b/.docs/architecture/m4-sections-plan.md
@@ -16,22 +16,22 @@ dedicated stories / PRs per [`bravobyte-ai/git-history.md`](../../../bravobyte-a
 
 ### In
 
-| Deliverable                  | Story | Issue |
-| ---------------------------- | ----- | ----- |
-| `$components/blocks/types.ts` + `BlockRenderer` shell                    | M4a-1 | [#10](https://github.com/BravoByte-org/dolcevitact-web/issues/10) |
-| Six adapted shared-candidate blocks (hero, card_group, timeline, team, rich_text, cta/image_gallery if needed) | M4a-2 | " |
-| Three Dolce-Vita-first blocks (`block_event_details`, `block_rsvp_form` shell, `block_faq` + items)          | M4a-3 | " |
-| Editorial sticky nav + mobile drawer (`SiteNav` + `NavDrawer`), replaces the temp ribbon                      | M4b   | [#9](https://github.com/BravoByte-org/dolcevitact-web/issues/9)  |
-| Footer polish (keep current layout footer, tidy copy + socials if any)                                         | M4b   | [#9](https://github.com/BravoByte-org/dolcevitact-web/issues/9)  |
+| Deliverable                                                                                                    | Story | Issue                                                             |
+| -------------------------------------------------------------------------------------------------------------- | ----- | ----------------------------------------------------------------- |
+| `$components/blocks/types.ts` + `BlockRenderer` shell                                                          | M4a-1 | [#10](https://github.com/BravoByte-org/dolcevitact-web/issues/10) |
+| Six adapted shared-candidate blocks (hero, card_group, timeline, team, rich_text, cta/image_gallery if needed) | M4a-2 | "                                                                 |
+| Three Dolce-Vita-first blocks (`block_event_details`, `block_rsvp_form` shell, `block_faq` + items)            | M4a-3 | "                                                                 |
+| Editorial sticky nav + mobile drawer (`SiteNav` + `NavDrawer`), replaces the temp ribbon                       | M4b   | [#9](https://github.com/BravoByte-org/dolcevitact-web/issues/9)   |
+| Footer polish (keep current layout footer, tidy copy + socials if any)                                         | M4b   | [#9](https://github.com/BravoByte-org/dolcevitact-web/issues/9)   |
 
 ### Out (explicitly deferred)
 
-| Item | Where it lands |
-| ---- | -------------- |
+| Item                                                                                             | Where it lands                                                         |
+| ------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------- |
 | `block_rsvp_form` submit action (anonymous `POST /items/rsvp_submissions` → Resend notification) | M5 ([#11](https://github.com/BravoByte-org/dolcevitact-web/issues/11)) |
-| Image optimization (`@sveltejs/enhanced-img`), OG images, JSON-LD     | M6 ([#12](https://github.com/BravoByte-org/dolcevitact-web/issues/12)) |
-| Section entrance animations beyond what `$styles/motion.css` already provides | Captured in M6 polish pass |
-| Italian translations on CMS fields / UI strings                        | Parked (spec §7 — English-only v1)  |
+| Image optimization (`@sveltejs/enhanced-img`), OG images, JSON-LD                                | M6 ([#12](https://github.com/BravoByte-org/dolcevitact-web/issues/12)) |
+| Section entrance animations beyond what `$styles/motion.css` already provides                    | Captured in M6 polish pass                                             |
+| Italian translations on CMS fields / UI strings                                                  | Parked (spec §7 — English-only v1)                                     |
 
 ## 2. Component architecture
 
@@ -45,34 +45,34 @@ collections:
 
 ```svelte
 <script lang="ts">
-  import HeroBlock from './HeroBlock.svelte';
-  import RichTextBlock from './RichTextBlock.svelte';
-  import CardGroupBlock from './CardGroupBlock.svelte';
-  import TimelineBlock from './TimelineBlock.svelte';
-  import TeamBlock from './TeamBlock.svelte';
-  // DV-first
-  import EventDetailsBlock from './EventDetailsBlock.svelte';
-  import RsvpFormBlock from './RsvpFormBlock.svelte';
-  import FaqBlock from './FaqBlock.svelte';
+	import HeroBlock from './HeroBlock.svelte';
+	import RichTextBlock from './RichTextBlock.svelte';
+	import CardGroupBlock from './CardGroupBlock.svelte';
+	import TimelineBlock from './TimelineBlock.svelte';
+	import TeamBlock from './TeamBlock.svelte';
+	// DV-first
+	import EventDetailsBlock from './EventDetailsBlock.svelte';
+	import RsvpFormBlock from './RsvpFormBlock.svelte';
+	import FaqBlock from './FaqBlock.svelte';
 
-  import type { Block } from './types';
-  let { blocks = [] }: { blocks: Block[] } = $props();
+	import type { Block } from './types';
+	let { blocks = [] }: { blocks: Block[] } = $props();
 
-  const componentMap = {
-    block_hero: HeroBlock,
-    block_rich_text: RichTextBlock,
-    block_card_group: CardGroupBlock,
-    block_timeline: TimelineBlock,
-    block_team: TeamBlock,
-    block_event_details: EventDetailsBlock,
-    block_rsvp_form: RsvpFormBlock,
-    block_faq: FaqBlock,
-  } as const;
+	const componentMap = {
+		block_hero: HeroBlock,
+		block_rich_text: RichTextBlock,
+		block_card_group: CardGroupBlock,
+		block_timeline: TimelineBlock,
+		block_team: TeamBlock,
+		block_event_details: EventDetailsBlock,
+		block_rsvp_form: RsvpFormBlock,
+		block_faq: FaqBlock
+	} as const;
 </script>
 
 {#each blocks as block, i (`${block.collection}-${block.item.id ?? i}`)}
-  {@const Component = componentMap[block.collection as keyof typeof componentMap]}
-  {#if Component}<Component data={block.item as never} />{/if}
+	{@const Component = componentMap[block.collection as keyof typeof componentMap]}
+	{#if Component}<Component data={block.item as never} />{/if}
 {/each}
 ```
 
@@ -82,16 +82,16 @@ Until then, keep the `Block = { collection: string; item: Record<string, unknown
 
 ### 2.2 Per-block components (directory: `src/lib/components/blocks/`)
 
-| File                    | Directus collection     | Starway origin? | Brand adaptations required                                                     |
-| ----------------------- | ----------------------- | --------------- | ------------------------------------------------------------------------------ |
-| `HeroBlock.svelte`      | `block_hero`            | ✓               | Replace utility color + type scales with DV tokens (Cormorant display + terracotta CTA); adopt `Grain` + `GoldRule` decoratives |
-| `RichTextBlock.svelte`  | `block_rich_text`       | ✓               | Scoped prose styles using `--dv-color-charcoal` / serif body, `OliveBranch` flourish at top if `variant === 'editorial'` |
-| `CardGroupBlock.svelte` | `block_card_group`      | ✓               | Strip trucking-specific hover effects; keep image-backed variant flag; use ivory/terracotta/sage trio |
-| `TimelineBlock.svelte`  | `block_timeline`        | ✓               | Replace Starway vertical-rule with DV `GoldRule` dividers; smaller year labels in script font |
-| `TeamBlock.svelte`      | `block_team`            | ✓               | Single-founder-optimized layout (most DV usage is n=1); bio reads as editorial paragraph, not Starway's card grid |
-| `EventDetailsBlock.svelte`   | `block_event_details` | ✗ (NEW) | Structured card: eyebrow, date/time/city stack, location note, CTA pill. Anchor via `cta_anchor` to `#rsvp`. |
-| `RsvpFormBlock.svelte`       | `block_rsvp_form`    | ✗ (NEW) | M4: renders the shell (heading, copy, fields, consent, success/error slots). M5: hooks `enhance` to the `/reserve` form action. No network I/O this milestone. |
-| `FaqBlock.svelte`            | `block_faq`          | ✗ (NEW) | Accordion pattern. Wraps child `block_faq_items` as `<details>`/`<summary>` for progressive-enhancement-first a11y. |
+| File                       | Directus collection   | Starway origin? | Brand adaptations required                                                                                                                                     |
+| -------------------------- | --------------------- | --------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `HeroBlock.svelte`         | `block_hero`          | ✓               | Replace utility color + type scales with DV tokens (Cormorant display + terracotta CTA); adopt `Grain` + `GoldRule` decoratives                                |
+| `RichTextBlock.svelte`     | `block_rich_text`     | ✓               | Scoped prose styles using `--dv-color-charcoal` / serif body, `OliveBranch` flourish at top if `variant === 'editorial'`                                       |
+| `CardGroupBlock.svelte`    | `block_card_group`    | ✓               | Strip trucking-specific hover effects; keep image-backed variant flag; use ivory/terracotta/sage trio                                                          |
+| `TimelineBlock.svelte`     | `block_timeline`      | ✓               | Replace Starway vertical-rule with DV `GoldRule` dividers; smaller year labels in script font                                                                  |
+| `TeamBlock.svelte`         | `block_team`          | ✓               | Single-founder-optimized layout (most DV usage is n=1); bio reads as editorial paragraph, not Starway's card grid                                              |
+| `EventDetailsBlock.svelte` | `block_event_details` | ✗ (NEW)         | Structured card: eyebrow, date/time/city stack, location note, CTA pill. Anchor via `cta_anchor` to `#rsvp`.                                                   |
+| `RsvpFormBlock.svelte`     | `block_rsvp_form`     | ✗ (NEW)         | M4: renders the shell (heading, copy, fields, consent, success/error slots). M5: hooks `enhance` to the `/reserve` form action. No network I/O this milestone. |
+| `FaqBlock.svelte`          | `block_faq`           | ✗ (NEW)         | Accordion pattern. Wraps child `block_faq_items` as `<details>`/`<summary>` for progressive-enhancement-first a11y.                                            |
 
 For the 5 Starway-origin blocks, the work is **scoped CSS replacement**,
 not structural rewrite — the markup, prop shapes, data flow, and M2A
@@ -145,22 +145,22 @@ classes in the rendered markup.
 Track each as a candidate. Extraction happens when a third client
 requests the same shape — until then, stay client-local per Rule Zero.
 
-| Candidate                                      | Why it's shared-candidate                                                                                     | Extraction trigger       |
-| ---------------------------------------------- | ------------------------------------------------------------------------------------------------------------- | ------------------------ |
-| `BlockRenderer` registry pattern               | Identical shape already in Starway; the registry map is the only delta per client                             | 3rd client adopts blocks |
-| `HeroBlock`, `RichTextBlock`, `CardGroupBlock`, `TimelineBlock`, `TeamBlock` contracts + **un-styled** primitives | Markup structure + prop shape are shared; only CSS is client-local                                   | 3rd client adopts blocks |
-| `NavDrawer` + `HamburgerButton` (body-scroll-lock, focus trap, `aria-modal`) | Pure a11y utilities, zero brand opinions                                                     | 2nd use (Starway also needs a drawer for complex nav — already partial) |
-| `breakpoints.css` em-based custom media set    | Identical values across clients; zero brand variance                                                          | 3rd client adopts Tailwind v4 |
-| `EventDetailsBlock` + `RsvpFormBlock` + `FaqBlock` + `FaqItem` shells | DV-first but the contracts are already shared in `@bravobyte/types` per M1; the unstyled shells are the next layer up | 2nd client needs event/RSVP/FAQ flows |
+| Candidate                                                                                                         | Why it's shared-candidate                                                                                             | Extraction trigger                                                      |
+| ----------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
+| `BlockRenderer` registry pattern                                                                                  | Identical shape already in Starway; the registry map is the only delta per client                                     | 3rd client adopts blocks                                                |
+| `HeroBlock`, `RichTextBlock`, `CardGroupBlock`, `TimelineBlock`, `TeamBlock` contracts + **un-styled** primitives | Markup structure + prop shape are shared; only CSS is client-local                                                    | 3rd client adopts blocks                                                |
+| `NavDrawer` + `HamburgerButton` (body-scroll-lock, focus trap, `aria-modal`)                                      | Pure a11y utilities, zero brand opinions                                                                              | 2nd use (Starway also needs a drawer for complex nav — already partial) |
+| `breakpoints.css` em-based custom media set                                                                       | Identical values across clients; zero brand variance                                                                  | 3rd client adopts Tailwind v4                                           |
+| `EventDetailsBlock` + `RsvpFormBlock` + `FaqBlock` + `FaqItem` shells                                             | DV-first but the contracts are already shared in `@bravobyte/types` per M1; the unstyled shells are the next layer up | 2nd client needs event/RSVP/FAQ flows                                   |
 
 ## 5. Testing plan
 
-| Layer      | Coverage                                                                                                      | Tool                             |
-| ---------- | ------------------------------------------------------------------------------------------------------------- | -------------------------------- |
-| Component  | Each block renders with a minimal prop set; `BlockRenderer` skips unknown collections without throwing        | `vitest` + `@testing-library/svelte` |
-| Integration| `/` renders 9 blocks when Directus returns the seeded homepage; falls back to M3 placeholder on load failure  | `vitest` (SSR smoke)             |
-| A11y       | `NavDrawer` traps focus, restores on close, `Esc` closes; `FaqBlock` keyboard-navigable via `<details>`        | `@axe-core/playwright`           |
-| Visual     | No blank states, no utility-class leak, fonts load (Cormorant, Tangerine, Inter); Lighthouse ≥ 95 deferred to M6 | Playwright + manual preview      |
+| Layer       | Coverage                                                                                                         | Tool                                 |
+| ----------- | ---------------------------------------------------------------------------------------------------------------- | ------------------------------------ |
+| Component   | Each block renders with a minimal prop set; `BlockRenderer` skips unknown collections without throwing           | `vitest` + `@testing-library/svelte` |
+| Integration | `/` renders 9 blocks when Directus returns the seeded homepage; falls back to M3 placeholder on load failure     | `vitest` (SSR smoke)                 |
+| A11y        | `NavDrawer` traps focus, restores on close, `Esc` closes; `FaqBlock` keyboard-navigable via `<details>`          | `@axe-core/playwright`               |
+| Visual      | No blank states, no utility-class leak, fonts load (Cormorant, Tangerine, Inter); Lighthouse ≥ 95 deferred to M6 | Playwright + manual preview          |
 
 Unit tests are optional for pure presentational components where the
 markup and prop shape are the full contract; SSR + a11y smoke tests are

--- a/.docs/operations/m2-verification.md
+++ b/.docs/operations/m2-verification.md
@@ -7,14 +7,14 @@ safe; this file documents the initial apply for audit.
 
 ## Steps executed
 
-| # | Step                                | Outcome                                                                                          |
-| - | ----------------------------------- | ------------------------------------------------------------------------------------------------ |
-| 1 | Merge [PR #18][pr18]                | closes the 4-commit dry-run robustness fix chain; all CI green (Install / Lint / Typecheck / Unit / Build / Vercel Preview) |
-| 2 | `--seed --dry-run`                  | Read-only preview: zero creates, zero deletes, ~40 idempotent metadata PATCHes on existing fields + collections + two relation `meta.one_field`/`sort_field` nudges. Confirms the live schema matches what the committed script wants. |
-| 3 | `--seed` (real apply)               | Applied 40+ PATCHes silently (apply mode doesn't print each one). Completed clean; exit 0. |
-| 4 | Anonymous `POST /items/rsvp_submissions` | `HTTP 204` (success) — this revealed a bug, see below.                                      |
-| 5 | Patch `migrate.mjs` for the bug     | Commit included in this PR; re-ran `--seed --skip-schema` to backfill the missing Public permission. Output: `+ perm create rsvp_submissions on policy abf8a154…`. |
-| 6 | Re-verify anonymous `POST`          | `HTTP 204` again — now backed by a real Public permission row, not a coincidental Directus default. |
+| #   | Step                                     | Outcome                                                                                                                                                                                                                                |
+| --- | ---------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | Merge [PR #18][pr18]                     | closes the 4-commit dry-run robustness fix chain; all CI green (Install / Lint / Typecheck / Unit / Build / Vercel Preview)                                                                                                            |
+| 2   | `--seed --dry-run`                       | Read-only preview: zero creates, zero deletes, ~40 idempotent metadata PATCHes on existing fields + collections + two relation `meta.one_field`/`sort_field` nudges. Confirms the live schema matches what the committed script wants. |
+| 3   | `--seed` (real apply)                    | Applied 40+ PATCHes silently (apply mode doesn't print each one). Completed clean; exit 0.                                                                                                                                             |
+| 4   | Anonymous `POST /items/rsvp_submissions` | `HTTP 204` (success) — this revealed a bug, see below.                                                                                                                                                                                 |
+| 5   | Patch `migrate.mjs` for the bug          | Commit included in this PR; re-ran `--seed --skip-schema` to backfill the missing Public permission. Output: `+ perm create rsvp_submissions on policy abf8a154…`.                                                                     |
+| 6   | Re-verify anonymous `POST`               | `HTTP 204` again — now backed by a real Public permission row, not a coincidental Directus default.                                                                                                                                    |
 
 [pr18]: https://github.com/BravoByte-org/dolcevitact-web/pull/18
 
@@ -52,22 +52,22 @@ breaks in prod" class of bug.
 
 ## Live state after M2 close
 
-| Artifact                             | Status / ID                                                   |
-| ------------------------------------ | ------------------------------------------------------------- |
-| `dolcevita` site row                 | `d934e7c1-6b20-4ea8-aaa7-ba7343d43b2c`                        |
-| `Dolce Vita Content` editor policy   | `61af0ccc-b1e5-4258-a356-0e0d09e135b2`                        |
-| `Dolce Vita Editor` role             | `19dd94b4-1407-4b5c-b30d-63c414c71a7a`                        |
-| `Dolce Vita App Service` user        | `f48174ea-0702-45cc-843f-bc6c2c66b844`                        |
-| App Service token (in `.env`)        | valid — `/users/me` returns `HTTP 200`                        |
-| `block_faq` + `block_faq_items`      | created, `display_template` = `{{title}}` / `{{question}}`    |
-| `block_event_details`                | created, `display_template` = `{{title}} — {{date}}`          |
-| `block_rsvp_form`                    | created, `display_template` = `{{title}}`                     |
-| `rsvp_submissions`                   | created, `display_template` = `{{name}} — {{email}}`, archive_field=`status` archive_value=`cancelled` |
-| `page_blocks` M2A `one_allowed_collections` | includes all 3 new block parents + the pre-existing 8  |
-| Placeholder homepage                 | `a92a946c-d116-4abe-b143-cd084f2eff20`, 9 blocks              |
-| Published Content Reader → read      | all 4 new block collections                                   |
-| Dolce Vita Content (editor) → CRU    | all 4 new block collections, `rsvp_submissions` R+U only      |
-| **Public → create on `rsvp_submissions`** | backfilled after the policy-name-fix re-run (allow-list: site/name/email/phone/baby_age/message/event_ref/source) |
+| Artifact                                    | Status / ID                                                                                                       |
+| ------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| `dolcevita` site row                        | `d934e7c1-6b20-4ea8-aaa7-ba7343d43b2c`                                                                            |
+| `Dolce Vita Content` editor policy          | `61af0ccc-b1e5-4258-a356-0e0d09e135b2`                                                                            |
+| `Dolce Vita Editor` role                    | `19dd94b4-1407-4b5c-b30d-63c414c71a7a`                                                                            |
+| `Dolce Vita App Service` user               | `f48174ea-0702-45cc-843f-bc6c2c66b844`                                                                            |
+| App Service token (in `.env`)               | valid — `/users/me` returns `HTTP 200`                                                                            |
+| `block_faq` + `block_faq_items`             | created, `display_template` = `{{title}}` / `{{question}}`                                                        |
+| `block_event_details`                       | created, `display_template` = `{{title}} — {{date}}`                                                              |
+| `block_rsvp_form`                           | created, `display_template` = `{{title}}`                                                                         |
+| `rsvp_submissions`                          | created, `display_template` = `{{name}} — {{email}}`, archive_field=`status` archive_value=`cancelled`            |
+| `page_blocks` M2A `one_allowed_collections` | includes all 3 new block parents + the pre-existing 8                                                             |
+| Placeholder homepage                        | `a92a946c-d116-4abe-b143-cd084f2eff20`, 9 blocks                                                                  |
+| Published Content Reader → read             | all 4 new block collections                                                                                       |
+| Dolce Vita Content (editor) → CRU           | all 4 new block collections, `rsvp_submissions` R+U only                                                          |
+| **Public → create on `rsvp_submissions`**   | backfilled after the policy-name-fix re-run (allow-list: site/name/email/phone/baby_age/message/event_ref/source) |
 
 ## Not applied (intentional)
 

--- a/.docs/operations/m2-verification.md
+++ b/.docs/operations/m2-verification.md
@@ -1,0 +1,92 @@
+# M2 — Directus migration verification runlog
+
+One-time record of the first real `node scripts/directus/migrate.mjs --seed`
+run against the shared BravoByte Directus instance (`https://cms.bravobyte.co`),
+performed on **April 21, 2026**. The script is idempotent, so re-runs are
+safe; this file documents the initial apply for audit.
+
+## Steps executed
+
+| # | Step                                | Outcome                                                                                          |
+| - | ----------------------------------- | ------------------------------------------------------------------------------------------------ |
+| 1 | Merge [PR #18][pr18]                | closes the 4-commit dry-run robustness fix chain; all CI green (Install / Lint / Typecheck / Unit / Build / Vercel Preview) |
+| 2 | `--seed --dry-run`                  | Read-only preview: zero creates, zero deletes, ~40 idempotent metadata PATCHes on existing fields + collections + two relation `meta.one_field`/`sort_field` nudges. Confirms the live schema matches what the committed script wants. |
+| 3 | `--seed` (real apply)               | Applied 40+ PATCHes silently (apply mode doesn't print each one). Completed clean; exit 0. |
+| 4 | Anonymous `POST /items/rsvp_submissions` | `HTTP 204` (success) — this revealed a bug, see below.                                      |
+| 5 | Patch `migrate.mjs` for the bug     | Commit included in this PR; re-ran `--seed --skip-schema` to backfill the missing Public permission. Output: `+ perm create rsvp_submissions on policy abf8a154…`. |
+| 6 | Re-verify anonymous `POST`          | `HTTP 204` again — now backed by a real Public permission row, not a coincidental Directus default. |
+
+[pr18]: https://github.com/BravoByte-org/dolcevitact-web/pull/18
+
+## Bug found + fixed during verification
+
+**Symptom:** Admin probe showed zero `Public` permission rows on
+`rsvp_submissions` after the first real apply, even though the script's
+`backfillPermissions` function clearly intended to grant Public `create`
+there (see header comment line 31, "Public: create-only on
+`rsvp_submissions` (allow-list fields)").
+
+**Root cause:** `findPolicyByName('Public')` (line 729 pre-fix) looked up
+the Public policy by the literal string `"Public"`. Directus stores
+system policy names as i18n translation keys — the built-in Public policy
+is stored as `$t:public_label`. The filter returned an empty array,
+`pub` was `null`, and the `if (pub)` guard silently skipped the
+permission row. No warning, no failure.
+
+**Impact if un-fixed:** M5 RSVP form submissions would silently return
+`403 FORBIDDEN` from every anonymous visitor — a "works in admin,
+breaks in prod" class of bug.
+
+**Fix (this PR):**
+
+1. `findPolicyByName` now accepts a variadic list of candidate names
+   (first match wins) and is rewritten to fall back through each.
+2. The call-site in `backfillPermissions` passes both `'Public'` and
+   `'$t:public_label'` and prints a `⚠` warning if neither matches
+   (parallel to the existing Published Content Reader warn at line
+   723-727).
+3. The Apr 21 Directus permissions rule at
+   [`bravobyte-ai/rules/directus-collection-permissions.md`](../../../bravobyte-ai/rules/directus-collection-permissions.md)
+   gained a "Looking up system policies by name" section codifying the
+   pattern — future migration scripts on other clients inherit the fix.
+
+## Live state after M2 close
+
+| Artifact                             | Status / ID                                                   |
+| ------------------------------------ | ------------------------------------------------------------- |
+| `dolcevita` site row                 | `d934e7c1-6b20-4ea8-aaa7-ba7343d43b2c`                        |
+| `Dolce Vita Content` editor policy   | `61af0ccc-b1e5-4258-a356-0e0d09e135b2`                        |
+| `Dolce Vita Editor` role             | `19dd94b4-1407-4b5c-b30d-63c414c71a7a`                        |
+| `Dolce Vita App Service` user        | `f48174ea-0702-45cc-843f-bc6c2c66b844`                        |
+| App Service token (in `.env`)        | valid — `/users/me` returns `HTTP 200`                        |
+| `block_faq` + `block_faq_items`      | created, `display_template` = `{{title}}` / `{{question}}`    |
+| `block_event_details`                | created, `display_template` = `{{title}} — {{date}}`          |
+| `block_rsvp_form`                    | created, `display_template` = `{{title}}`                     |
+| `rsvp_submissions`                   | created, `display_template` = `{{name}} — {{email}}`, archive_field=`status` archive_value=`cancelled` |
+| `page_blocks` M2A `one_allowed_collections` | includes all 3 new block parents + the pre-existing 8  |
+| Placeholder homepage                 | `a92a946c-d116-4abe-b143-cd084f2eff20`, 9 blocks              |
+| Published Content Reader → read      | all 4 new block collections                                   |
+| Dolce Vita Content (editor) → CRU    | all 4 new block collections, `rsvp_submissions` R+U only      |
+| **Public → create on `rsvp_submissions`** | backfilled after the policy-name-fix re-run (allow-list: site/name/email/phone/baby_age/message/event_ref/source) |
+
+## Not applied (intentional)
+
+- **en-US / client-locale field translations** — per
+  `spec.md §7 Out of scope for v1`, Dolce Vita is English-only at launch.
+  The rule at `bravobyte-ai/rules/directus-collection-display.md` still
+  expects translations on multi-locale clients; it's correctly skipped
+  here and should be revisited if/when a second locale is added.
+
+## Residual cleanup
+
+One smoke-test row was created in `rsvp_submissions` during step 4 (anonymous
+`POST` with `source=m2-verification-runlog`). The local admin token only
+has the MCP Agent role which lacks `read` on this collection, so the row
+could not be deleted from this session. **Human admin should delete it
+via the Directus admin UI** before M5 goes live.
+
+## Cross-references
+
+- Runbook: [`./directus-migration.md`](./directus-migration.md)
+- Rules: [`bravobyte-ai/rules/directus-collection-permissions.md`](../../../bravobyte-ai/rules/directus-collection-permissions.md) · [`bravobyte-ai/rules/directus-collection-display.md`](../../../bravobyte-ai/rules/directus-collection-display.md)
+- ADR: [`../adrs/0001-dolce-vita-architecture.md`](../adrs/0001-dolce-vita-architecture.md)

--- a/scripts/directus/migrate.mjs
+++ b/scripts/directus/migrate.mjs
@@ -272,13 +272,27 @@ async function ensureSite() {
 	return r.data.id;
 }
 
-/** Look up an existing policy by name; null if not found. */
-async function findPolicyByName(name) {
-	const r = await api(
-		'GET',
-		`/policies?filter[name][_eq]=${encodeURIComponent(name)}&fields=id,name&limit=1`
-	);
-	return r.data?.[0] ?? null;
+/**
+ * Look up an existing policy by name; null if not found.
+ *
+ * Directus stores some system policy names as i18n translation keys (e.g.
+ * the built-in Public policy is stored as literal `$t:public_label`, which
+ * the admin UI resolves to "Public"). API filters match the raw stored
+ * value, not the rendered label — so callers must pass every candidate
+ * name the target policy might have. The first match wins.
+ *
+ * See `bravobyte-ai/rules/directus-collection-permissions.md` → "Looking
+ * up system policies by name".
+ */
+async function findPolicyByName(...names) {
+	for (const name of names) {
+		const r = await api(
+			'GET',
+			`/policies?filter[name][_eq]=${encodeURIComponent(name)}&fields=id,name&limit=1`
+		);
+		if (r.data?.[0]) return r.data[0];
+	}
+	return null;
 }
 
 /** Look up an existing role by name; null if not found. */
@@ -726,7 +740,14 @@ async function backfillPermissions(editorPolicyId) {
 		);
 	}
 
-	const pub = await findPolicyByName('Public');
+	// Directus stores the built-in Public policy name as the i18n key
+	// `$t:public_label`; only translates to "Public" in the admin UI.
+	const pub = await findPolicyByName('Public', '$t:public_label');
+	if (!pub) {
+		console.warn(
+			'  ⚠ Public policy not found under either "Public" or "$t:public_label"; skipping Public create on rsvp_submissions. Check the policies list in Directus admin and re-run.'
+		);
+	}
 
 	// Published Content Reader (shared SSR read): permissions:{} on block collections
 	// since they're reached only via site-scoped pages.

--- a/scripts/directus/seed-navigation.mjs
+++ b/scripts/directus/seed-navigation.mjs
@@ -1,0 +1,178 @@
+#!/usr/bin/env node
+/*
+ * Dolce Vita CT — navigation seed
+ * --------------------------------------------------------------
+ * Idempotent upsert of the `header` navigation row + its section
+ * anchor items for the `dolcevita` site. Re-runnable safely; if
+ * the row or items already exist, their sort + title + url fields
+ * are PATCHed instead of duplicated.
+ *
+ * Usage:
+ *   DIRECTUS_ADMIN_TOKEN=<token> node scripts/directus/seed-navigation.mjs
+ *   DIRECTUS_ADMIN_TOKEN=<token> node scripts/directus/seed-navigation.mjs --dry-run
+ *
+ * Env:
+ *   DIRECTUS_URL           defaults to https://cms.bravobyte.co
+ *   DIRECTUS_ADMIN_TOKEN   required; system-admin token with nav CRU
+ *   SITE_KEY               defaults to "dolcevita"
+ *
+ * M4b deliverable — see PR on BravoByte-org/dolcevitact-web.
+ */
+
+import process from 'node:process';
+
+const ARGS = new Set(process.argv.slice(2));
+const DRY_RUN = ARGS.has('--dry-run');
+
+const DIRECTUS_URL = (process.env.DIRECTUS_URL ?? 'https://cms.bravobyte.co').replace(/\/$/, '');
+const ADMIN_TOKEN = process.env.DIRECTUS_ADMIN_TOKEN;
+const SITE_KEY = process.env.SITE_KEY ?? 'dolcevita';
+const NAV_KEY = 'header';
+
+if (!ADMIN_TOKEN) {
+	console.error(
+		'\n✗ DIRECTUS_ADMIN_TOKEN is required.\n  Export an admin token and retry:\n  DIRECTUS_ADMIN_TOKEN=… node scripts/directus/seed-navigation.mjs\n'
+	);
+	process.exit(1);
+}
+
+// ──────────────────────────────────────────────────────────────────────
+//  HTTP helper (GET always executes; writes are skipped in --dry-run)
+// ──────────────────────────────────────────────────────────────────────
+
+async function api(method, path, body) {
+	if (DRY_RUN && method !== 'GET') {
+		console.log(`  [dry-run] ${method} ${path}`, body ? JSON.stringify(body).slice(0, 200) : '');
+		return { data: { id: `dry-run-${Math.random().toString(16).slice(2, 10)}` } };
+	}
+
+	const res = await fetch(`${DIRECTUS_URL}${path}`, {
+		method,
+		headers: {
+			Authorization: `Bearer ${ADMIN_TOKEN}`,
+			'Content-Type': 'application/json'
+		},
+		body: body ? JSON.stringify(body) : undefined
+	});
+
+	const text = await res.text();
+	const json = text ? JSON.parse(text) : null;
+
+	if (!res.ok) {
+		const message = json?.errors?.[0]?.message ?? text;
+		const err = new Error(`${method} ${path} → ${res.status}: ${message}`);
+		err.status = res.status;
+		err.payload = json;
+		throw err;
+	}
+
+	return json;
+}
+
+async function findOne(collection, filter, fields = ['id']) {
+	const qs = new URLSearchParams({
+		filter: JSON.stringify(filter),
+		fields: fields.join(','),
+		limit: '1'
+	});
+	const r = await api('GET', `/items/${collection}?${qs}`);
+	return r.data?.[0] ?? null;
+}
+
+// ──────────────────────────────────────────────────────────────────────
+//  Nav definition
+// ──────────────────────────────────────────────────────────────────────
+
+/**
+ * Order matches the spec's 10-section flow (hero is implicit, RSVP is
+ * promoted to the pill CTA by SiteNav on the client). Every `url`
+ * targets an anchor on the same page because the marketing site is a
+ * single-page experience; the site-scoped `fetchNavigation` treats
+ * these as ordinary links.
+ */
+const NAV_ITEMS = [
+	{ title: 'The experience', url: '#about', sort: 1 },
+	{ title: 'How it works', url: '#how-it-works', sort: 2 },
+	{ title: 'For you', url: '#who-its-for', sort: 3 },
+	{ title: 'Your guide', url: '#founder', sort: 4 },
+	{ title: 'Event', url: '#event', sort: 5 },
+	{ title: 'FAQ', url: '#faq', sort: 6 },
+	{ title: 'Reserve', url: '#rsvp', sort: 7 }
+];
+
+// ──────────────────────────────────────────────────────────────────────
+//  Main
+// ──────────────────────────────────────────────────────────────────────
+
+async function main() {
+	console.log(
+		`\n→ Seeding navigation for site=${SITE_KEY} key=${NAV_KEY} on ${DIRECTUS_URL}${
+			DRY_RUN ? ' (dry-run)' : ''
+		}\n`
+	);
+
+	const site = await findOne('sites', { key: { _eq: SITE_KEY } });
+	if (!site) {
+		throw new Error(
+			`sites row with key="${SITE_KEY}" not found — run scripts/directus/migrate.mjs first.`
+		);
+	}
+	console.log(`  site.id = ${site.id}`);
+
+	let nav = await findOne(
+		'navigation',
+		{ _and: [{ key: { _eq: NAV_KEY } }, { site: { _eq: site.id } }] },
+		['id', 'is_active']
+	);
+	if (!nav) {
+		console.log(`  + creating navigation row key=${NAV_KEY}`);
+		const r = await api('POST', '/items/navigation', {
+			key: NAV_KEY,
+			site: site.id,
+			is_active: true,
+			label: 'Dolce Vita — header'
+		});
+		nav = r.data;
+	} else if (!nav.is_active) {
+		console.log(`  ≡ reactivating navigation row`);
+		await api('PATCH', `/items/navigation/${nav.id}`, { is_active: true });
+	} else {
+		console.log(`  ≡ navigation row exists`);
+	}
+
+	for (const item of NAV_ITEMS) {
+		const existing = await findOne(
+			'navigation_items',
+			{
+				_and: [{ navigation: { _eq: nav.id } }, { url: { _eq: item.url } }]
+			},
+			['id']
+		);
+		const payload = {
+			navigation: nav.id,
+			title: item.title,
+			url: item.url,
+			sort: item.sort,
+			open_in_new_tab: false
+		};
+		if (existing) {
+			console.log(`    ≡ ${item.url} (${item.title})`);
+			await api('PATCH', `/items/navigation_items/${existing.id}`, {
+				title: item.title,
+				sort: item.sort,
+				open_in_new_tab: false
+			});
+		} else {
+			console.log(`    + ${item.url} (${item.title})`);
+			await api('POST', '/items/navigation_items', payload);
+		}
+	}
+
+	console.log('\n✓ Navigation seed complete.\n');
+}
+
+main().catch((err) => {
+	console.error('\n✗ Seed failed.');
+	console.error(err);
+	process.exit(1);
+});

--- a/spec.md
+++ b/spec.md
@@ -2,7 +2,7 @@
 
 > **Owner:** BravoByteLLC for Dolce Vita CT
 > **Domain:** https://dolcevitact.com
-> **Status:** M2 Directus schema — migration script + app-side plumbing in review; Directus admin-token run pending
+> **Status:** M2 Directus schema — **complete** (migration applied + verified Apr 21 2026; see [`.docs/operations/m2-verification.md`](./.docs/operations/m2-verification.md)). M4 (sections) is now the active milestone.
 > **Last Updated:** April 21, 2026
 
 This is the single source of truth for what `dolcevitact-web` is, why it exists,
@@ -80,9 +80,9 @@ The homepage is a single Directus `pages` row composed of M2A blocks:
 | M-1 | GitHub workspace         | done        | —                                                                  | Repo, labels, templates, board, epics, stories |
 | M0  | Foundation               | in progress | [#1](https://github.com/BravoByte-org/dolcevitact-web/milestone/1) | Scaffold + Directus site row + Vercel + DNS    |
 | M1  | Shared content contracts | in review   | [#2](https://github.com/BravoByte-org/dolcevitact-web/milestone/2) | `@bravobyte/types` extension (types PR #2)     |
-| M2  | Directus schema          | in review   | [#3](https://github.com/BravoByte-org/dolcevitact-web/milestone/3) | Idempotent migration script + app plumbing     |
+| M2  | Directus schema          | done        | [#3](https://github.com/BravoByte-org/dolcevitact-web/milestone/3) | Idempotent migration applied + verified Apr 21 2026 (runlog: [`.docs/operations/m2-verification.md`](./.docs/operations/m2-verification.md)) |
 | M3  | Design system            | done        | [#4](https://github.com/BravoByte-org/dolcevitact-web/milestone/4) | Tokens, decoratives, motion (PR #16 merged)    |
-| M4  | Sections                 | planned     | [#5](https://github.com/BravoByte-org/dolcevitact-web/milestone/5) | 9 sections + nav + footer                      |
+| M4  | Sections                 | in progress | [#5](https://github.com/BravoByte-org/dolcevitact-web/milestone/5) | 9 sections + nav + footer — plan: [`.docs/architecture/m4-sections-plan.md`](./.docs/architecture/m4-sections-plan.md) |
 | M5  | RSVP                     | planned     | [#6](https://github.com/BravoByte-org/dolcevitact-web/milestone/6) | Form action + Resend                           |
 | M6  | Launch                   | planned     | [#7](https://github.com/BravoByte-org/dolcevitact-web/milestone/7) | SEO, a11y, deploy                              |
 

--- a/spec.md
+++ b/spec.md
@@ -75,16 +75,16 @@ The homepage is a single Directus `pages` row composed of M2A blocks:
 
 ## 5. Milestones
 
-| ID  | Name                     | Status      | GitHub Milestone                                                   | Notes                                          |
-| --- | ------------------------ | ----------- | ------------------------------------------------------------------ | ---------------------------------------------- |
-| M-1 | GitHub workspace         | done        | —                                                                  | Repo, labels, templates, board, epics, stories |
-| M0  | Foundation               | in progress | [#1](https://github.com/BravoByte-org/dolcevitact-web/milestone/1) | Scaffold + Directus site row + Vercel + DNS    |
-| M1  | Shared content contracts | in review   | [#2](https://github.com/BravoByte-org/dolcevitact-web/milestone/2) | `@bravobyte/types` extension (types PR #2)     |
+| ID  | Name                     | Status      | GitHub Milestone                                                   | Notes                                                                                                                                        |
+| --- | ------------------------ | ----------- | ------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| M-1 | GitHub workspace         | done        | —                                                                  | Repo, labels, templates, board, epics, stories                                                                                               |
+| M0  | Foundation               | in progress | [#1](https://github.com/BravoByte-org/dolcevitact-web/milestone/1) | Scaffold + Directus site row + Vercel + DNS                                                                                                  |
+| M1  | Shared content contracts | in review   | [#2](https://github.com/BravoByte-org/dolcevitact-web/milestone/2) | `@bravobyte/types` extension (types PR #2)                                                                                                   |
 | M2  | Directus schema          | done        | [#3](https://github.com/BravoByte-org/dolcevitact-web/milestone/3) | Idempotent migration applied + verified Apr 21 2026 (runlog: [`.docs/operations/m2-verification.md`](./.docs/operations/m2-verification.md)) |
-| M3  | Design system            | done        | [#4](https://github.com/BravoByte-org/dolcevitact-web/milestone/4) | Tokens, decoratives, motion (PR #16 merged)    |
-| M4  | Sections                 | in progress | [#5](https://github.com/BravoByte-org/dolcevitact-web/milestone/5) | 9 sections + nav + footer — plan: [`.docs/architecture/m4-sections-plan.md`](./.docs/architecture/m4-sections-plan.md) |
-| M5  | RSVP                     | planned     | [#6](https://github.com/BravoByte-org/dolcevitact-web/milestone/6) | Form action + Resend                           |
-| M6  | Launch                   | planned     | [#7](https://github.com/BravoByte-org/dolcevitact-web/milestone/7) | SEO, a11y, deploy                              |
+| M3  | Design system            | done        | [#4](https://github.com/BravoByte-org/dolcevitact-web/milestone/4) | Tokens, decoratives, motion (PR #16 merged)                                                                                                  |
+| M4  | Sections                 | in progress | [#5](https://github.com/BravoByte-org/dolcevitact-web/milestone/5) | 9 sections + nav + footer — plan: [`.docs/architecture/m4-sections-plan.md`](./.docs/architecture/m4-sections-plan.md)                       |
+| M5  | RSVP                     | planned     | [#6](https://github.com/BravoByte-org/dolcevitact-web/milestone/6) | Form action + Resend                                                                                                                         |
+| M6  | Launch                   | planned     | [#7](https://github.com/BravoByte-org/dolcevitact-web/milestone/7) | SEO, a11y, deploy                                                                                                                            |
 
 GitHub Project board: [BravoByte/Dolce Vita CT Board](https://github.com/orgs/BravoByte-org/projects/4)
 

--- a/src/lib/components/navigation/HamburgerButton.svelte
+++ b/src/lib/components/navigation/HamburgerButton.svelte
@@ -1,0 +1,76 @@
+<script lang="ts">
+	let {
+		open = false,
+		controls,
+		onclick
+	}: {
+		open?: boolean;
+		controls: string;
+		onclick?: (event: MouseEvent) => void;
+	} = $props();
+</script>
+
+<button
+	type="button"
+	class="dv-hamburger"
+	class:dv-hamburger--open={open}
+	aria-expanded={open}
+	aria-controls={controls}
+	aria-label={open ? 'Close menu' : 'Open menu'}
+	{onclick}
+>
+	<span class="dv-hamburger__line"></span>
+	<span class="dv-hamburger__line"></span>
+	<span class="dv-hamburger__line"></span>
+</button>
+
+<style>
+	.dv-hamburger {
+		position: relative;
+		display: inline-flex;
+		flex-direction: column;
+		justify-content: center;
+		align-items: center;
+		gap: 0.28rem;
+		width: 2.5rem;
+		height: 2.5rem;
+		padding: 0;
+		background: transparent;
+		border: 1px solid transparent;
+		border-radius: 9999px;
+		cursor: pointer;
+		transition:
+			background-color var(--dv-duration-fast) var(--dv-ease-soft),
+			border-color var(--dv-duration-fast) var(--dv-ease-soft);
+	}
+
+	.dv-hamburger:hover,
+	.dv-hamburger:focus-visible {
+		background: color-mix(in srgb, var(--dv-color-gold) 12%, transparent);
+		border-color: color-mix(in srgb, var(--dv-color-gold) 40%, transparent);
+		outline: none;
+	}
+
+	.dv-hamburger__line {
+		display: block;
+		width: 1.1rem;
+		height: 1px;
+		background: var(--dv-color-charcoal);
+		transition:
+			transform var(--dv-duration-base) var(--dv-ease-soft),
+			opacity var(--dv-duration-fast) var(--dv-ease-soft);
+		transform-origin: center;
+	}
+
+	.dv-hamburger--open .dv-hamburger__line:nth-child(1) {
+		transform: translateY(0.37rem) rotate(45deg);
+	}
+
+	.dv-hamburger--open .dv-hamburger__line:nth-child(2) {
+		opacity: 0;
+	}
+
+	.dv-hamburger--open .dv-hamburger__line:nth-child(3) {
+		transform: translateY(-0.37rem) rotate(-45deg);
+	}
+</style>

--- a/src/lib/components/navigation/SiteFooter.svelte
+++ b/src/lib/components/navigation/SiteFooter.svelte
@@ -1,0 +1,209 @@
+<script lang="ts">
+	import { base } from '$app/paths';
+	import GoldRule from '$components/decor/GoldRule.svelte';
+	import OliveBranch from '$components/decor/OliveBranch.svelte';
+	import type { NavItem, NavChild } from './types';
+
+	let {
+		items = [],
+		siteTitle = 'Dolce Vita CT',
+		contactEmail = 'hello@dolcevitact.com',
+		cityLine = 'Stamford, Connecticut',
+		tagline = 'An Italian-inspired circle for mothers and babies.'
+	}: {
+		items?: NavItem[];
+		siteTitle?: string;
+		contactEmail?: string;
+		cityLine?: string;
+		tagline?: string;
+	} = $props();
+
+	const navItems = $derived(items.slice(0, 6));
+
+	const year = new Date().getFullYear();
+
+	function resolveHref(item: NavChild): string {
+		if (item.url) {
+			const u = item.url;
+			if (u.startsWith('#')) return u;
+			if (/^https?:\/\//i.test(u) || u.startsWith('//') || u.startsWith('mailto:')) return u;
+			const path = u.startsWith('/') ? u : `/${u}`;
+			return `${base}${path}`;
+		}
+		if (item.page?.slug) {
+			const slug = item.page.slug.startsWith('/') ? item.page.slug : `/${item.page.slug}`;
+			return `${base}${slug}`;
+		}
+		return '#';
+	}
+</script>
+
+<footer class="dv-footer">
+	<div class="dv-footer__rule">
+		<GoldRule size="md" />
+	</div>
+
+	<div class="dv-footer__inner">
+		<div class="dv-footer__brand">
+			<div class="dv-footer__olive" aria-hidden="true">
+				<OliveBranch tone="sage" />
+			</div>
+			<p class="dv-footer__script">{siteTitle}</p>
+			<p class="dv-footer__tagline">{tagline}</p>
+		</div>
+
+		{#if navItems.length > 0}
+			<nav class="dv-footer__nav" aria-label="Footer">
+				<p class="dv-eyebrow dv-footer__nav-heading">Explore</p>
+				<ul>
+					{#each navItems as item (item.id)}
+						<li>
+							<a
+								class="dv-footer__link"
+								href={resolveHref(item)}
+								target={item.open_in_new_tab ? '_blank' : undefined}
+								rel={item.open_in_new_tab ? 'noopener noreferrer' : undefined}
+							>
+								{item.title}
+							</a>
+						</li>
+					{/each}
+				</ul>
+			</nav>
+		{/if}
+
+		<div class="dv-footer__contact">
+			<p class="dv-eyebrow dv-footer__nav-heading">Reach us</p>
+			<a class="dv-footer__email" href="mailto:{contactEmail}">{contactEmail}</a>
+			<p class="dv-footer__city">{cityLine}</p>
+		</div>
+	</div>
+
+	<div class="dv-footer__meta">
+		<p>&copy; {year} {siteTitle} · Made with amore in Connecticut.</p>
+	</div>
+</footer>
+
+<style>
+	.dv-footer {
+		margin-top: auto;
+		padding: 4rem 1.5rem 2.5rem;
+		background: color-mix(in srgb, var(--dv-color-ivory-deep) 80%, var(--dv-color-ivory));
+		position: relative;
+	}
+
+	.dv-footer__rule {
+		max-width: 12rem;
+		margin-inline: auto;
+	}
+
+	.dv-footer__inner {
+		margin-top: 3rem;
+		margin-inline: auto;
+		max-width: 64rem;
+		display: grid;
+		gap: 3rem;
+		grid-template-columns: 1fr;
+		text-align: center;
+	}
+
+	@media (min-width: 720px) {
+		.dv-footer__inner {
+			grid-template-columns: 1.4fr 1fr 1fr;
+			text-align: left;
+			align-items: start;
+		}
+	}
+
+	.dv-footer__olive {
+		width: 9rem;
+		margin-inline: auto;
+		margin-bottom: 1rem;
+	}
+
+	@media (min-width: 720px) {
+		.dv-footer__olive {
+			margin-inline: 0;
+		}
+	}
+
+	.dv-footer__script {
+		font-family: var(--dv-font-script);
+		font-size: clamp(2.5rem, 1.6rem + 2vw, 3.5rem);
+		color: var(--dv-color-terracotta-deep);
+		line-height: 1;
+	}
+
+	.dv-footer__tagline {
+		margin-top: 0.75rem;
+		max-width: 22rem;
+		font-family: var(--dv-font-display);
+		font-size: 1.1rem;
+		line-height: 1.5;
+		color: var(--dv-color-charcoal-soft);
+	}
+
+	@media (min-width: 720px) {
+		.dv-footer__tagline {
+			margin-inline: 0;
+		}
+	}
+
+	.dv-footer__nav-heading {
+		margin-bottom: 1rem;
+	}
+
+	.dv-footer__nav ul {
+		list-style: none;
+		padding: 0;
+		margin: 0;
+		display: flex;
+		flex-direction: column;
+		gap: 0.65rem;
+	}
+
+	.dv-footer__link {
+		font-family: var(--dv-font-display);
+		font-size: 1.05rem;
+		color: var(--dv-color-charcoal);
+		text-decoration: none;
+		transition: color var(--dv-duration-fast) var(--dv-ease-soft);
+	}
+
+	.dv-footer__link:hover {
+		color: var(--dv-color-terracotta-deep);
+	}
+
+	.dv-footer__email {
+		display: block;
+		font-family: var(--dv-font-display);
+		font-size: 1.15rem;
+		color: var(--dv-color-terracotta-deep);
+		text-decoration: none;
+	}
+
+	.dv-footer__email:hover {
+		text-decoration: underline;
+		text-underline-offset: 4px;
+		text-decoration-color: color-mix(in srgb, var(--dv-color-terracotta) 50%, transparent);
+	}
+
+	.dv-footer__city {
+		margin-top: 0.5rem;
+		font-family: var(--dv-font-sans);
+		font-size: 0.85rem;
+		color: var(--dv-color-charcoal-soft);
+	}
+
+	.dv-footer__meta {
+		margin-top: 3.5rem;
+		padding-top: 1.75rem;
+		border-top: 1px solid color-mix(in srgb, var(--dv-color-charcoal) 6%, transparent);
+		text-align: center;
+		font-family: var(--dv-font-sans);
+		font-size: 0.72rem;
+		letter-spacing: var(--dv-tracking-eyebrow);
+		text-transform: uppercase;
+		color: var(--dv-color-charcoal-mute);
+	}
+</style>

--- a/src/lib/components/navigation/SiteNav.svelte
+++ b/src/lib/components/navigation/SiteNav.svelte
@@ -1,0 +1,376 @@
+<script lang="ts">
+	import { base } from '$app/paths';
+	import HamburgerButton from './HamburgerButton.svelte';
+	import type { NavItem, NavChild } from './types';
+
+	let {
+		items = [],
+		siteTitle = 'Dolce Vita CT',
+		ctaLabel = 'Reserve',
+		ctaHref = '#rsvp'
+	}: {
+		items?: NavItem[];
+		siteTitle?: string;
+		ctaLabel?: string;
+		ctaHref?: string;
+	} = $props();
+
+	const MOBILE_PANEL_ID = 'dv-nav-mobile-panel';
+
+	let mobileOpen = $state(false);
+	let scrolled = $state(false);
+	let panelRef: HTMLDivElement | null = $state(null);
+	let hamburgerWrapperRef: HTMLDivElement | null = $state(null);
+
+	/**
+	 * Filter out the Reserve/CTA item from the inline link list so the
+	 * pill CTA never duplicates it. Treated by exact slug match on `#rsvp`
+	 * or a title that matches the `ctaLabel` — either works from the CMS
+	 * side without a dedicated flag field.
+	 */
+	const inlineItems = $derived(
+		items.filter((item) => {
+			const href = resolveHref(item);
+			return href !== ctaHref && item.title?.toLowerCase() !== ctaLabel.toLowerCase();
+		})
+	);
+
+	function resolveHref(item: NavChild): string {
+		if (item.url) {
+			const u = item.url;
+			if (u.startsWith('#')) return u;
+			if (/^https?:\/\//i.test(u) || u.startsWith('//') || u.startsWith('mailto:')) return u;
+			const path = u.startsWith('/') ? u : `/${u}`;
+			return `${base}${path}`;
+		}
+		if (item.page?.slug) {
+			const slug = item.page.slug.startsWith('/') ? item.page.slug : `/${item.page.slug}`;
+			return `${base}${slug}`;
+		}
+		return '#';
+	}
+
+	function closeMobile() {
+		mobileOpen = false;
+	}
+
+	function toggleMobile() {
+		mobileOpen = !mobileOpen;
+	}
+
+	function onKey(e: KeyboardEvent) {
+		if (e.key === 'Escape' && mobileOpen) {
+			e.preventDefault();
+			closeMobile();
+			hamburgerWrapperRef?.querySelector<HTMLButtonElement>('button')?.focus();
+		}
+	}
+
+	function onScroll() {
+		scrolled = window.scrollY > 16;
+	}
+
+	// Scroll listener: adds a hairline rule + tighter padding once the user
+	// scrolls past the hero, so the sticky bar gains authority without ever
+	// feeling like a heavy corporate top-bar.
+	$effect(() => {
+		if (typeof window === 'undefined') return;
+		onScroll();
+		window.addEventListener('scroll', onScroll, { passive: true });
+		return () => window.removeEventListener('scroll', onScroll);
+	});
+
+	// Body scroll lock while the drawer is open, with focus pulled into the
+	// first focusable element inside the panel for keyboard users.
+	$effect(() => {
+		if (typeof document === 'undefined') return;
+		const cls = 'dv-scroll-locked';
+		if (mobileOpen) {
+			document.body.classList.add(cls);
+			const firstLink = panelRef?.querySelector<HTMLElement>('a, button');
+			firstLink?.focus();
+		} else {
+			document.body.classList.remove(cls);
+		}
+		return () => document.body.classList.remove(cls);
+	});
+</script>
+
+<svelte:window onkeydown={onKey} />
+
+<header class="dv-nav" class:dv-nav--scrolled={scrolled}>
+	<div class="dv-nav__bar">
+		<a href="/" class="dv-nav__brand" onclick={closeMobile}>
+			<span class="dv-nav__brand-script">{siteTitle}</span>
+		</a>
+
+		<nav class="dv-nav__desktop" aria-label="Primary">
+			{#each inlineItems as item (item.id)}
+				<a
+					class="dv-nav__link"
+					href={resolveHref(item)}
+					target={item.open_in_new_tab ? '_blank' : undefined}
+					rel={item.open_in_new_tab ? 'noopener noreferrer' : undefined}
+				>
+					{item.title}
+				</a>
+			{/each}
+			<a class="dv-nav__cta" href={ctaHref}>{ctaLabel}</a>
+		</nav>
+
+		<div class="dv-nav__mobile-trigger" bind:this={hamburgerWrapperRef}>
+			<HamburgerButton open={mobileOpen} controls={MOBILE_PANEL_ID} onclick={toggleMobile} />
+		</div>
+	</div>
+</header>
+
+{#if mobileOpen}
+	<button type="button" class="dv-nav__scrim" aria-label="Close menu" onclick={closeMobile}
+	></button>
+{/if}
+
+<div
+	id={MOBILE_PANEL_ID}
+	class="dv-nav__panel"
+	class:dv-nav__panel--open={mobileOpen}
+	role="dialog"
+	aria-modal="true"
+	aria-label="Main menu"
+	aria-hidden={!mobileOpen}
+	inert={!mobileOpen}
+	bind:this={panelRef}
+>
+	<div class="dv-nav__panel-inner">
+		<p class="dv-nav__panel-brand dv-script">{siteTitle}</p>
+
+		<ul class="dv-nav__panel-list">
+			{#each inlineItems as item (item.id)}
+				<li>
+					<a
+						class="dv-nav__panel-link"
+						href={resolveHref(item)}
+						target={item.open_in_new_tab ? '_blank' : undefined}
+						rel={item.open_in_new_tab ? 'noopener noreferrer' : undefined}
+						onclick={closeMobile}
+					>
+						{item.title}
+					</a>
+				</li>
+			{/each}
+		</ul>
+
+		<a class="dv-nav__panel-cta" href={ctaHref} onclick={closeMobile}>{ctaLabel}</a>
+
+		<p class="dv-nav__panel-meta">Stamford · Connecticut</p>
+	</div>
+</div>
+
+<style>
+	.dv-nav {
+		position: sticky;
+		top: 0;
+		z-index: 60;
+		background: color-mix(in srgb, var(--dv-color-ivory) 85%, transparent);
+		-webkit-backdrop-filter: saturate(140%) blur(12px);
+		backdrop-filter: saturate(140%) blur(12px);
+		border-bottom: 1px solid transparent;
+		transition:
+			border-color var(--dv-duration-base) var(--dv-ease-soft),
+			box-shadow var(--dv-duration-base) var(--dv-ease-soft),
+			padding var(--dv-duration-base) var(--dv-ease-soft);
+	}
+
+	.dv-nav--scrolled {
+		border-bottom-color: color-mix(in srgb, var(--dv-color-charcoal) 8%, transparent);
+		box-shadow: 0 1px 0 0 color-mix(in srgb, var(--dv-color-gold) 25%, transparent);
+	}
+
+	.dv-nav__bar {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 1.5rem;
+		margin-inline: auto;
+		max-width: 80rem;
+		padding: 1.25rem 1.5rem;
+	}
+
+	.dv-nav--scrolled .dv-nav__bar {
+		padding-block: 0.9rem;
+	}
+
+	.dv-nav__brand {
+		color: var(--dv-color-charcoal);
+		text-decoration: none;
+	}
+
+	.dv-nav__brand-script {
+		font-family: var(--dv-font-script);
+		font-size: clamp(1.75rem, 1.2rem + 1vw, 2.25rem);
+		line-height: 1;
+		color: var(--dv-color-terracotta-deep);
+	}
+
+	.dv-nav__desktop {
+		display: none;
+		align-items: center;
+		gap: 2rem;
+	}
+
+	@media (min-width: 840px) {
+		.dv-nav__desktop {
+			display: flex;
+		}
+	}
+
+	.dv-nav__link {
+		font-family: var(--dv-font-sans);
+		font-size: 0.72rem;
+		letter-spacing: var(--dv-tracking-eyebrow);
+		text-transform: uppercase;
+		color: var(--dv-color-charcoal-soft);
+		text-decoration: none;
+		transition: color var(--dv-duration-fast) var(--dv-ease-soft);
+	}
+
+	.dv-nav__link:hover {
+		color: var(--dv-color-terracotta-deep);
+	}
+
+	.dv-nav__cta {
+		margin-left: 0.5rem;
+		padding: 0.65rem 1.35rem;
+		background: var(--dv-color-terracotta);
+		color: var(--dv-color-ivory);
+		font-family: var(--dv-font-sans);
+		font-size: 0.72rem;
+		letter-spacing: var(--dv-tracking-eyebrow);
+		text-transform: uppercase;
+		border-radius: 9999px;
+		text-decoration: none;
+		transition: background-color var(--dv-duration-fast) var(--dv-ease-soft);
+	}
+
+	.dv-nav__cta:hover {
+		background: var(--dv-color-terracotta-deep);
+	}
+
+	.dv-nav__mobile-trigger {
+		display: flex;
+		align-items: center;
+	}
+
+	@media (min-width: 840px) {
+		.dv-nav__mobile-trigger {
+			display: none;
+		}
+	}
+
+	/* ---------- mobile drawer ---------- */
+
+	.dv-nav__scrim {
+		position: fixed;
+		inset: 0;
+		z-index: 55;
+		background: color-mix(in srgb, var(--dv-color-charcoal) 30%, transparent);
+		-webkit-backdrop-filter: blur(2px);
+		backdrop-filter: blur(2px);
+		border: none;
+		cursor: default;
+	}
+
+	@media (min-width: 840px) {
+		.dv-nav__scrim {
+			display: none;
+		}
+	}
+
+	.dv-nav__panel {
+		position: fixed;
+		inset: 0;
+		z-index: 65;
+		pointer-events: none;
+		background: var(--dv-color-ivory);
+		transform: translateY(-16px);
+		opacity: 0;
+		transition:
+			transform var(--dv-duration-base) var(--dv-ease-soft),
+			opacity var(--dv-duration-base) var(--dv-ease-soft);
+	}
+
+	.dv-nav__panel--open {
+		pointer-events: auto;
+		transform: translateY(0);
+		opacity: 1;
+	}
+
+	@media (min-width: 840px) {
+		.dv-nav__panel,
+		.dv-nav__panel--open {
+			display: none;
+		}
+	}
+
+	.dv-nav__panel-inner {
+		display: flex;
+		flex-direction: column;
+		min-height: 100%;
+		padding: 5rem 2rem 3rem;
+		text-align: center;
+	}
+
+	.dv-nav__panel-brand {
+		font-size: clamp(3rem, 2rem + 3vw, 4rem);
+		color: var(--dv-color-terracotta-deep);
+		margin-bottom: 2.5rem;
+	}
+
+	.dv-nav__panel-list {
+		list-style: none;
+		padding: 0;
+		margin: 0;
+		display: flex;
+		flex-direction: column;
+		gap: 1.25rem;
+	}
+
+	.dv-nav__panel-link {
+		display: inline-block;
+		font-family: var(--dv-font-display);
+		font-size: 1.5rem;
+		color: var(--dv-color-charcoal);
+		text-decoration: none;
+	}
+
+	.dv-nav__panel-link:hover {
+		color: var(--dv-color-terracotta-deep);
+	}
+
+	.dv-nav__panel-cta {
+		margin-top: 3rem;
+		align-self: center;
+		padding: 0.9rem 2rem;
+		background: var(--dv-color-terracotta);
+		color: var(--dv-color-ivory);
+		font-family: var(--dv-font-sans);
+		font-size: 0.8rem;
+		letter-spacing: var(--dv-tracking-eyebrow);
+		text-transform: uppercase;
+		border-radius: 9999px;
+		text-decoration: none;
+	}
+
+	.dv-nav__panel-meta {
+		margin-top: auto;
+		padding-top: 3rem;
+		font-family: var(--dv-font-sans);
+		font-size: 0.72rem;
+		letter-spacing: var(--dv-tracking-eyebrow);
+		text-transform: uppercase;
+		color: var(--dv-color-charcoal-mute);
+	}
+
+	:global(.dv-scroll-locked) {
+		overflow: hidden;
+	}
+</style>

--- a/src/lib/components/navigation/types.ts
+++ b/src/lib/components/navigation/types.ts
@@ -1,0 +1,19 @@
+/**
+ * Navigation row shape returned by `fetchNavigation(...)`.
+ *
+ * Mirrors Directus' `navigation_items` surface: either a raw `url` (used
+ * for section anchors on the single-page marketing site, e.g. `#rsvp`) or
+ * a linked `page.slug` (used when a nav item targets another route).
+ */
+export type NavChild = {
+	id: string | number;
+	title: string;
+	url?: string | null;
+	open_in_new_tab?: boolean | null;
+	sort?: number | null;
+	page?: { slug: string; title: string } | null;
+};
+
+export type NavItem = NavChild & {
+	children?: NavChild[] | null;
+};

--- a/src/routes/(app)/+layout.svelte
+++ b/src/routes/(app)/+layout.svelte
@@ -1,6 +1,9 @@
 <script lang="ts">
 	import '../../app.css';
 	import Grain from '$components/decor/Grain.svelte';
+	import SiteNav from '$components/navigation/SiteNav.svelte';
+	import SiteFooter from '$components/navigation/SiteFooter.svelte';
+	import type { NavItem } from '$components/navigation/types';
 	import type { LayoutData } from './$types';
 	import type { Snippet } from 'svelte';
 
@@ -10,6 +13,7 @@
 		(data.site as { title?: string | null; description?: string | null } | null) ?? null
 	);
 	const siteTitle = $derived(site?.title ?? 'Dolce Vita CT');
+	const navItems = $derived(((data.navigation ?? []) as NavItem[]) ?? []);
 </script>
 
 <svelte:head>
@@ -41,32 +45,33 @@
 <a href="#main" class="dv-skip-link">Skip to content</a>
 
 <div class="dv-shell">
-	<!--
-		M4b will replace this temporary ribbon with a real editorial sticky nav
-		+ mobile drawer. Kept minimal here so M4a focuses strictly on the
-		Directus → BlockRenderer wiring.
-	-->
-	<header class="dv-shell__header">
-		<a href="/" class="dv-shell__brand">
-			<span class="dv-script">{siteTitle}</span>
-		</a>
-	</header>
+	<SiteNav items={navItems} {siteTitle} />
 
 	<main id="main" class="dv-shell__main">
 		{@render children?.()}
 	</main>
 
-	<footer class="dv-shell__footer">
-		<div class="dv-shell__footer-inner">
-			<p class="dv-shell__footer-brand">{siteTitle}</p>
-			<p class="dv-shell__footer-meta">
-				Stamford, Connecticut · &copy; {new Date().getFullYear()}
-			</p>
-		</div>
-	</footer>
+	<SiteFooter items={navItems} {siteTitle} />
 </div>
 
 <style>
+	/*
+	 * Smooth in-page jumps for the sticky nav's section anchors. Scroll
+	 * offset matches the default nav bar height (64px compact, ~80px on
+	 * the wider bar) so the heading lands just under the sticky ribbon
+	 * instead of hiding behind it.
+	 */
+	:global(html) {
+		scroll-behavior: smooth;
+		scroll-padding-top: 5rem;
+	}
+
+	@media (prefers-reduced-motion: reduce) {
+		:global(html) {
+			scroll-behavior: auto;
+		}
+	}
+
 	.dv-skip-link {
 		position: absolute;
 		left: -9999px;
@@ -89,44 +94,7 @@
 		z-index: 10;
 	}
 
-	.dv-shell__header {
-		display: flex;
-		justify-content: center;
-		padding: 2rem 1.5rem 1rem;
-	}
-
-	.dv-shell__brand {
-		color: var(--dv-color-charcoal);
-	}
-
 	.dv-shell__main {
 		flex: 1;
-	}
-
-	.dv-shell__footer {
-		margin-top: auto;
-		padding: 3rem 1.5rem 2.5rem;
-		border-top: 1px solid color-mix(in srgb, var(--dv-color-charcoal) 8%, transparent);
-	}
-
-	.dv-shell__footer-inner {
-		margin-inline: auto;
-		max-width: 48rem;
-		text-align: center;
-	}
-
-	.dv-shell__footer-brand {
-		font-family: var(--dv-font-script, serif);
-		font-size: 2rem;
-		color: var(--dv-color-terracotta-deep);
-	}
-
-	.dv-shell__footer-meta {
-		margin-top: 0.5rem;
-		font-family: var(--dv-font-sans);
-		font-size: 0.72rem;
-		letter-spacing: 0.18em;
-		text-transform: uppercase;
-		color: var(--dv-color-charcoal-mute);
 	}
 </style>


### PR DESCRIPTION
## Summary

Part of M4 / closes partial for #9 (sections). Stacks on top of **PR #20** (M4a) — merge that first and this PR will auto-retarget to `next`.

Replaces the placeholder header/footer from M4a with real editorial chrome wired to the Directus `navigation` + `navigation_items` collections.

### What's in the nav
- Sticky ivory top bar with saturate+blur backdrop; hairline gold/charcoal rule fades in after 16px of scroll so the bar gains authority without ever feeling like a corporate top-bar.
- Desktop: brand (Tangerine script, terracotta-deep) on the left; eyebrow-cased anchor links + a terracotta "Reserve" pill CTA on the right.
- Mobile (<840px): hamburger that morphs to ✕; full-screen ivory drawer with script brand, big serif anchor links, bottom CTA + city meta. ESC + backdrop click close; body scroll locked; first focusable element pulled into focus.
- SiteNav auto-detects the `#rsvp` nav item and promotes it to the pill CTA so the CMS only has one "Reserve" row.

### What's in the footer
- Ivory-deep base, gold rule divider, olive branch, script brand, tagline.
- Three-column grid at ≥720px: brand / Explore / Reach us; collapses to centered single column below.
- Copyright + "Made with amore in Connecticut" meta row.

### What's in Directus
- New idempotent script `scripts/directus/seed-navigation.mjs` that upserts the `header` navigation row + 7 anchor items (`#about`, `#how-it-works`, `#who-its-for`, `#founder`, `#event`, `#faq`, `#rsvp`) scoped to the `dolcevita` site.
- Re-runnable safely — existing rows are PATCHed in place.

## Handoff (one-time)

After merge, the seed needs to run **once** against prod Directus to populate the nav. Same admin-token flow as M2:

```bash
# temporarily set admin token in local .env
DIRECTUS_ADMIN_TOKEN=<your_admin_token> node scripts/directus/seed-navigation.mjs --dry-run   # verify
DIRECTUS_ADMIN_TOKEN=<your_admin_token> node scripts/directus/seed-navigation.mjs              # apply
# clear the admin token from .env again
```

No Vercel env changes needed — the nav uses the existing App Service token for reads.

## Test plan
- [x] `pnpm check` — 0 errors, 0 warnings
- [x] `pnpm lint` — clean
- [x] `pnpm build` — Vercel adapter build clean
- [x] `pnpm preview` renders the sticky nav + Reserve CTA + footer against the real Directus
- [ ] Vercel preview deploy shows the same — graceful empty state until the seed runs
- [ ] After seed, the 6 inline links + Reserve pill appear on desktop; drawer renders them on mobile

## Graceful degradation
- No navigation row seeded → desktop shows brand + Reserve pill only; drawer shows brand + CTA + city meta. Nothing 404s or breaks.
- Directus unreachable → same empty state; layout loader already returns `navigation: []` on error.

## Follow-ups
- **M4c** — promote each block from "editorial-neutral" to its full section design (hero background, event card photography, alternating sage-grain sections, etc.)
- **M5** — enable the RSVP form (`?/rsvp` action + `rsvp_submissions` write + Resend notify)

Made with [Cursor](https://cursor.com)