### PR TITLE
fix(brand): promote Dolce Vita rename onto next (recovery from stacked-PR merge)

### DIFF
--- a/.ai/README.md
+++ b/.ai/README.md
@@ -1,4 +1,4 @@
-# .ai — Dolce Vita CT
+# .ai — Dolce Vita
 
 Repo-local AI configuration. Inherits from the workspace-level
 [`bravobyte-ai`](../../bravobyte-ai) repo, which holds the canonical

--- a/.cursor/rules/dolcevita-project.mdc
+++ b/.cursor/rules/dolcevita-project.mdc
@@ -1,15 +1,36 @@
 ---
-description: Dolce Vita CT delivery repo — context, scope, and house style
+description: Dolce Vita delivery repo — context, scope, and house style
 globs:
 alwaysApply: true
 ---
 
-# Dolce Vita CT — repo context
+# Dolce Vita — repo context
 
 You are working in `dolcevitact-web`, a **thin BravoByte delivery repo** that
-ships the marketing single-page application for [dolcevitact.com](https://dolcevitact.com)
-— a premium Italian-inspired mom & baby experience in Stamford, Connecticut,
-owned by BravoByteLLC.
+ships the marketing single-page application for [dolcevitact.com](https://dolcevitact.com).
+
+## Brand vs. offering vs. domain
+
+- **Brand:** Dolce Vita — a premium Italian-inspired lifestyle brand owned by BravoByteLLC.
+- **Current offering (first chapter):** Dolce Vita Baby Circle — an Italian-inspired mama & bambino class in Stamford, CT.
+- **Domain:** `dolcevitact.com` — the `ct` suffix is a domain-availability quirk (Connecticut state code), not part of the brand name. Never write "Dolce Vita CT" in customer-facing copy.
+- **Future chapters under consideration:** cucina (homecooked Italian food service), online classes, newsletter.
+
+## Brand architecture: branded house, paths-first
+
+- The Dolce Vita parent brand owns the experience; new offerings live at sibling paths (`dolcevitact.com/cucina`, `/classes`, etc.) on the same domain rather than separate subdomains or domains.
+- See [`.docs/adrs/0002-brand-architecture.md`](mdc:.docs/adrs/0002-brand-architecture.md) for rationale and growth phases.
+- Decision tree before adding a new offering:
+  1. Is it the same audience and same brand promise? → new path on `dolcevitact.com`.
+  2. Different audience, same parent brand? → still new path, but with its own landing.
+  3. Truly separate sub-brand or platform? → re-evaluate; subdomain only if SEO + ops justify it.
+
+## Naming conventions in copy
+
+- **Headlines / SEO titles / page titles:** "Dolce Vita Baby Circle" (full offering name).
+- **Framing / hero script accent / parent-brand callouts:** "Dolce Vita" alone.
+- **Emails to customers:** sign as Dolce Vita, mention the specific offering when relevant.
+- **Never:** "Dolce Vita CT" anywhere customer-visible.
 
 ## Repo placement (Rule Zero recap)
 
@@ -45,7 +66,7 @@ owned by BravoByteLLC.
 
 ## Workflow
 
-- Issues tracked on the [BravoByte/Dolce Vita CT Board](https://github.com/orgs/BravoByte-org/projects/4).
+- Issues tracked on the [BravoByte/Dolce Vita Board](https://github.com/orgs/BravoByte-org/projects/4).
 - Milestones M-1 → M6 documented in [`spec.md`](mdc:spec.md).
 - Squash-merge PRs with conventional titles per the BravoByte git-history policy.
 - Update `spec.md` after every meaningful piece of work; keep it under 500 lines.

--- a/.docs/README.md
+++ b/.docs/README.md
@@ -1,4 +1,4 @@
-# .docs — Dolce Vita CT
+# .docs — Dolce Vita
 
 Repo-local documentation.
 

--- a/.docs/adrs/0001-dolce-vita-architecture.md
+++ b/.docs/adrs/0001-dolce-vita-architecture.md
@@ -1,15 +1,21 @@
-# ADR 0001 — Dolce Vita CT delivery architecture
+# ADR 0001 — Dolce Vita delivery architecture
 
 - **Status:** Accepted
 - **Date:** 2026-04-21
+- **Last revised:** 2026-04-25 (brand naming clarified; superseded in spirit by [ADR 0002](./0002-brand-architecture.md))
 - **Deciders:** Lion (Architect persona: Orion)
 - **Context:** Initial scaffold of `dolcevitact-web` for the dolcevitact.com launch.
 
 ## Context
 
-BravoByte received a second client engagement (Dolce Vita CT) requiring a
-boutique, premium marketing single-page application backed by a content
-management system, with an RSVP-capture flow as the primary conversion goal.
+BravoByte received a second client engagement, the **Dolce Vita** brand
+(launching with the Dolce Vita Baby Circle offering at `dolcevitact.com` —
+the `ct` suffix is a domain-availability quirk, not part of the brand).
+The brand requires a boutique, premium marketing single-page application
+backed by a content management system, with an RSVP-capture flow as the
+primary conversion goal. Brand architecture decisions (paths-first vs.
+subdomains, naming hierarchy) are recorded separately in
+[ADR 0002](./0002-brand-architecture.md).
 
 The original brief proposed React/Next.js. The BravoByte house stack is
 SvelteKit + Tailwind + TypeScript + Directus, already in production at

--- a/.docs/adrs/0002-brand-architecture.md
+++ b/.docs/adrs/0002-brand-architecture.md
@@ -1,0 +1,180 @@
+# ADR 0002 — Brand architecture: branded house, paths-first
+
+- **Status:** Accepted
+- **Date:** 2026-04-25
+- **Deciders:** Lion (with Architect persona: Orion)
+- **Related:** [ADR 0001 — Delivery architecture](./0001-dolce-vita-architecture.md)
+
+## Context
+
+The original brief framed `dolcevitact.com` as a single-purpose marketing site
+for "Dolce Vita CT — a premium Italian-inspired mom & baby experience". On
+April 25 2026, the founder clarified two important facts that change how the
+site should be modeled:
+
+1. **The brand name is "Dolce Vita", not "Dolce Vita CT".** The `ct` suffix
+   is purely a domain-availability artifact (Connecticut state code) — the
+   apex `dolcevita.com` was unavailable at registration time.
+2. **The Baby Circle is the first chapter of a larger brand,** not the brand
+   itself. Future chapters under consideration include:
+   - **Dolce Vita Cucina** — homecooked Italian food service
+   - **online classes** — Italian-curious adults
+   - a **newsletter** / lifestyle journal
+   - additional in-person experiences
+
+This raised an architecture question that needed to be answered _before_ the
+M6 launch and certainly before any second offering ships:
+
+> When the second offering launches, where does it live?
+> A separate domain? A subdomain? A new path on the same site?
+
+We had three credible options:
+
+| Option               | Example                              | Cost                               | SEO          | Ops                                      | Customer mental model             |
+| -------------------- | ------------------------------------ | ---------------------------------- | ------------ | ---------------------------------------- | --------------------------------- |
+| Separate domains     | `dolcevitababycircle.com` + new TLDs | High (registrar, DNS, SEO restart) | Fragmented   | N projects, N CMS sites, N analytics     | "Different companies"             |
+| Subdomain per brand  | `babycircle.dolcevitact.com`         | Medium                             | Diluted      | Still N projects, N CMS sites            | "Same family, different products" |
+| Paths on same domain | `dolcevitact.com/baby-circle`        | Low (one project, one CMS site)    | Consolidated | One project, one CMS site, one analytics | "One brand, multiple offerings" ✓ |
+
+For a startup brand at this stage — pre-revenue on the first offering, with
+unproven appetite for chapters two and three — the operational and SEO cost of
+splitting the brand surface is hard to justify.
+
+## Decision
+
+**Adopt a branded-house architecture rooted at `dolcevitact.com`, with new
+offerings added as paths rather than subdomains or separate domains.**
+
+Concretely:
+
+1. **One domain, one brand.** `dolcevitact.com` is the canonical home of the
+   Dolce Vita brand. The apex hosts the parent-brand surface and the current
+   live offering.
+2. **Paths-first for new offerings.** New chapters launch at sibling paths
+   (`/cucina`, `/classes`, `/journal`, etc.) on the same domain, in the same
+   SvelteKit app, backed by the same Directus `dolcevita` site.
+3. **Naming hierarchy in copy:**
+   - Parent brand: **Dolce Vita** (used in framing copy, hero script
+     accents, footer, email signatures).
+   - Offering name: **Dolce Vita Baby Circle**, **Dolce Vita Cucina**, etc.
+     (used in headlines, page titles, SEO titles, navigation).
+   - Never "Dolce Vita CT" in customer-facing copy. The `ct` suffix only
+     appears in the literal URL.
+4. **Subdomains are reserved for non-brand surfaces.** Examples that _would_
+   justify a subdomain in the future:
+   - `shop.dolcevitact.com` — a separate e-commerce platform that requires
+     its own framework, headless backend, or PCI surface.
+   - `cms.dolcevitact.com` / `app.dolcevitact.com` — admin or app surfaces.
+     We do not currently need these (we share `cms.bravobyte.co`).
+   - A spin-off brand that genuinely targets a different audience and breaks
+     the parent-brand promise.
+
+## Phased growth plan
+
+The architecture is implemented in three phases that match the business
+trajectory; we do not pre-build for phases that may never arrive.
+
+### Phase 1 — now (M0–M6)
+
+- `dolcevitact.com/` _is_ the Baby Circle landing page.
+- The Directus `pages` row at `slug=/` composes the Baby Circle blocks.
+- The hero, footer, and SEO frame the parent brand ("Dolce Vita") with the
+  offering name ("Baby Circle") in headlines and titles.
+- No `/baby-circle` path yet — it would be a redundant duplicate of `/`.
+
+### Phase 2 — second offering ships (e.g. Cucina)
+
+When the second offering moves from idea to commitment, we restructure
+without breaking SEO:
+
+- Move the Baby Circle homepage content to `slug=/baby-circle` (with a
+  301 redirect from `/` if we elect to convert `/` into a brand portal).
+- Either:
+  - **Option A (preferred):** Promote `/` to a thin **brand portal** that
+    introduces Dolce Vita and links to each chapter. Each chapter lives at
+    `/baby-circle`, `/cucina`, etc. Each is its own Directus `pages` row.
+  - **Option B:** Keep `/` as the Baby Circle home (most-trafficked), add
+    `/cucina` as a sibling. Use this if Baby Circle is still ~100% of
+    traffic and a portal would feel hollow.
+- Reuse the existing SvelteKit `(app)` route group, BlockRenderer, and
+  Directus block library wholesale. Each chapter is content, not code.
+- Navigation seed (`scripts/directus/seed-navigation.mjs`) gains a top-level
+  "Offerings" group or chapter-specific items.
+
+### Phase 3 — maturity (optional)
+
+- If a chapter outgrows the marketing-site shape (e.g. Cucina becomes a
+  full-blown ordering platform), promote it to its own subdomain
+  (`shop.dolcevitact.com`) with the marketing landing remaining at
+  `/cucina` linking to the platform.
+- Re-evaluate `dolcevita.com` apex acquisition once revenue justifies it;
+  if acquired, mirror content and 301 from `dolcevitact.com`.
+
+## Defensive actions (recommended)
+
+These are cheap insurance, not architectural commitments:
+
+- Register sibling domains as defensive holds, redirecting to
+  `dolcevitact.com`: `dolcevita.life`, `dolcevitalife.com`,
+  `dolcevita.kitchen`, etc. (founder's call; not required by this ADR).
+- Reserve common social handles under "DolceVita" + a chapter qualifier
+  (e.g. `@dolcevita.babycircle`).
+
+## Consequences
+
+### Positive
+
+- **One SEO surface to grow.** Authority compounds on `dolcevitact.com`
+  rather than splitting across N domains.
+- **One project to operate.** One Vercel project, one Directus site, one
+  analytics property, one CMS authoring experience, one design system.
+- **Lean-startup friendly.** Adding a chapter is content work, not
+  infrastructure work.
+- **Customer mental model is consistent.** "Dolce Vita has a Baby Circle and
+  a Cucina" reads more naturally than "Dolce Vita Baby Circle and Dolce
+  Vita Cucina are separate companies".
+- **Cheap to reverse.** If a chapter genuinely needs to spin out, we move
+  it to a subdomain with 301s and lose very little.
+
+### Negative
+
+- The `dolcevitact.com` URL is suboptimal forever. The `ct` reads like a
+  Connecticut suffix to anyone who knows US state codes; outside CT it
+  reads like noise. We mitigate by never typing "Dolce Vita CT" anywhere
+  customer-visible — copy always says "Dolce Vita" and the URL is just
+  the URL.
+- A future spin-off that needs a clean break has more URL surface to
+  redirect. Acceptable given how unlikely this is at the current stage.
+
+### Trade-offs
+
+- We accept that early SEO traffic to `/` will (in Phase 2) need to either
+  redirect or stay-and-be-the-Baby-Circle. We will decide between
+  Option A (brand portal at `/`) and Option B (Baby Circle at `/`) at the
+  time, based on the traffic split and the strategic story we want to tell.
+
+## How this ADR shows up in the codebase
+
+- `src/routes/(app)/+layout.svelte` — site title defaults to "Dolce Vita
+  Baby Circle"; meta description frames it as the first chapter of Dolce
+  Vita.
+- `src/routes/(app)/+page.svelte` — fallback hero uses parent brand
+  ("Dolce Vita") in script accent, with the Baby Circle named in the
+  headline.
+- `src/lib/components/navigation/SiteNav.svelte`,
+  `SiteFooter.svelte` — same naming convention.
+- `scripts/directus/migrate.mjs` — `sites.name = "Dolce Vita"`,
+  `sites.title = "Dolce Vita Baby Circle"`.
+- `scripts/directus/update-brand.mjs` — targeted, idempotent script that
+  updates the existing CMS rows to match the conventions in this ADR.
+  Created so we don't have to re-run the full `migrate.mjs --seed` (which
+  would only operate on a fresh database anyway).
+- `.cursor/rules/dolcevita-project.mdc` — the brand/offering/domain
+  decision tree and naming conventions are now part of the always-applied
+  project rules.
+
+## References
+
+- ADR 0001 — Delivery architecture
+- Workspace [`spec.md`](../../spec.md)
+- Founder conversation, 2026-04-25 (transcript on file)

--- a/.docs/operations/directus-migration.md
+++ b/.docs/operations/directus-migration.md
@@ -1,4 +1,4 @@
-# Directus migration runbook — Dolce Vita CT
+# Directus migration runbook — Dolce Vita
 
 One-shot migration that brings the shared BravoByte Directus instance
 (`https://cms.bravobyte.co`) into the shape `dolcevitact-web` expects. The

--- a/.env.example
+++ b/.env.example
@@ -30,7 +30,7 @@ DIRECTUS_ADMIN_TOKEN=""
 # (hello@, babycircle@) so the two never collide.
 RESEND_API_KEY=""
 RSVP_NOTIFY_EMAIL="babycircle@dolcevitact.com"
-RSVP_NOTIFY_FROM="Dolce Vita CT <ciao@ciao.dolcevitact.com>"
+RSVP_NOTIFY_FROM="Dolce Vita Baby Circle <reservations@ciao.dolcevitact.com>"
 
 # ──────────────────────────────────────────────────────────────────────
 #  Public site

--- a/README.md
+++ b/README.md
@@ -1,8 +1,14 @@
 # dolcevitact-web
 
-Marketing site for **Dolce Vita CT** at [dolcevitact.com](https://dolcevitact.com),
-a premium Italian-inspired mom & baby experience in Stamford, Connecticut.
-Owned and operated by **BravoByteLLC**.
+Marketing site for the **Dolce Vita** brand at
+[dolcevitact.com](https://dolcevitact.com), launching with our first chapter:
+the **Dolce Vita Baby Circle** — an Italian-inspired mama & bambino circle in
+Stamford, Connecticut. Owned and operated by **BravoByteLLC**.
+
+> Brand architecture: branded house, paths-first. The current site _is_ the
+> Baby Circle; future offerings (e.g. cucina, online classes, newsletters) live
+> at sibling paths like `dolcevitact.com/cucina` rather than separate domains
+> or subdomains. See [`.docs/adrs/0002-brand-architecture.md`](./.docs/adrs/0002-brand-architecture.md).
 
 Part of the [BravoByte](../bravobyte-ai) ecosystem. This is a **delivery
 repo** — it composes shared modules and stays thin. See
@@ -82,7 +88,7 @@ Strategize → Architect → Verify plan → Build → Verify code → Capture �
 Update.
 
 Issues are tracked on the
-[BravoByte/Dolce Vita CT Board](https://github.com/orgs/BravoByte-org/projects/4).
+[BravoByte/Dolce Vita Board](https://github.com/orgs/BravoByte-org/projects/4).
 Work follows the milestones M-1 → M6 documented in
 [`spec.md`](./spec.md#5-milestones).
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "dolcevitact.com",
-	"description": "Marketing site for Dolce Vita CT — premium Italian-inspired mom & baby experience in Stamford, CT.",
+	"description": "Marketing site for Dolce Vita Baby Circle — Italian-inspired mama & bambino circle in Stamford, CT, the first chapter of the Dolce Vita brand.",
 	"author": "BravoByteLLC <info@bravobyte.co>",
 	"version": "0.1.0",
 	"type": "module",

--- a/scripts/directus/migrate.mjs
+++ b/scripts/directus/migrate.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /**
- * Dolce Vita CT — one-shot Directus migration (idempotent)
+ * Dolce Vita — one-shot Directus migration (idempotent)
  * ──────────────────────────────────────────────────────────────────────
  *
  * Brings the shared BravoByte Directus instance (https://cms.bravobyte.co)
@@ -262,11 +262,12 @@ async function ensureSite() {
 	}
 	console.log(`  + creating site "${SITE_KEY}"`);
 	const r = await api('POST', '/items/sites', {
-		name: 'Dolce Vita CT',
+		name: 'Dolce Vita',
 		key: SITE_KEY,
 		url: 'https://dolcevitact.com',
-		title: 'Dolce Vita CT',
-		description: 'A premium Italian-inspired mom & baby experience in Stamford, Connecticut.',
+		title: 'Dolce Vita Baby Circle',
+		description:
+			'Dolce Vita Baby Circle — an Italian-inspired mama & bambino circle in Stamford, Connecticut. The first chapter of the Dolce Vita brand.',
 		status: 'published'
 	});
 	return r.data.id;
@@ -876,7 +877,7 @@ async function seedHomepage(siteId) {
 
 	const about = await api('POST', '/items/block_rich_text', {
 		content:
-			'<p>Dolce Vita CT is a small, intentional circle for Italian-curious families — a morning of music, language, and movement designed to feel like a Sunday in Liguria.</p>'
+			'<p>The Dolce Vita Baby Circle is a small, intentional gathering for Italian-curious families — a morning of music, language, and movement designed to feel like a Sunday in Liguria.</p>'
 	});
 
 	const timeline = await api('POST', '/items/block_timeline', {
@@ -953,16 +954,17 @@ async function seedHomepage(siteId) {
 		subtitle:
 			"Spots are limited to keep the circle intimate. We'll follow up within 24 hours to confirm your reservation.",
 		success_title: "Grazie — we'll be in touch",
-		success_body: 'Your note is in. Look for an email from hello@dolcevitact.com within a day.',
+		success_body:
+			'Your note is in. Look for an email from babycircle@dolcevitact.com within a day.',
 		consent_copy:
-			"By reserving you agree to receive a follow-up email from Dolce Vita CT. We don't share your information.",
+			"By reserving you agree to receive a follow-up email from the Dolce Vita Baby Circle. We don't share your information.",
 		site: siteId,
 		sort: 0
 	});
 
 	const story = await api('POST', '/items/block_rich_text', {
 		content:
-			'<p>Dolce Vita CT exists because raising a child between two languages should feel like a gift, not a chore. Our circles are the opposite of a class — they are small rituals built around the sounds of home.</p>'
+			'<p>Dolce Vita exists because raising a child between two languages should feel like a gift, not a chore. Our Baby Circle is the opposite of a class — it is a small ritual built around the sounds of home.</p>'
 	});
 
 	const faq = await api('POST', '/items/block_faq', {
@@ -999,13 +1001,13 @@ async function seedHomepage(siteId) {
 	console.log('  + creating pages row + page_blocks M2A wiring');
 	const page = await api('POST', '/items/pages', {
 		slug: '/',
-		title: 'Dolce Vita CT',
+		title: 'Dolce Vita Baby Circle',
 		status: 'published',
 		template_type: 'homepage',
 		site: siteId,
-		seo_title: 'Dolce Vita CT — Italian-inspired mom & baby experience in Stamford, CT',
+		seo_title: 'Dolce Vita Baby Circle — Italian-inspired mama & bambino in Stamford, CT',
 		seo_description:
-			'Reserve your spot at the Dolce Vita Baby Circle — a warm, refined Italian-inspired class for moms and babies in Stamford, Connecticut.'
+			'Reserve your spot at the Dolce Vita Baby Circle — a warm, refined Italian-inspired morning for mama and bambino in Stamford, Connecticut. The first chapter of Dolce Vita.'
 	});
 
 	const blockOrder = [
@@ -1036,7 +1038,7 @@ async function seedHomepage(siteId) {
 // ──────────────────────────────────────────────────────────────────────
 
 async function main() {
-	console.log(`\nDolce Vita CT — Directus migration (${DIRECTUS_URL})`);
+	console.log(`\nDolce Vita — Directus migration (${DIRECTUS_URL})`);
 	console.log(`  mode: ${DRY_RUN ? 'DRY RUN' : 'APPLY'}`);
 	console.log(`  site: ${SITE_KEY}`);
 	console.log(`  seed: ${DO_SEED}`);

--- a/scripts/directus/seed-navigation.mjs
+++ b/scripts/directus/seed-navigation.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /*
- * Dolce Vita CT — navigation seed
+ * Dolce Vita — navigation seed
  * --------------------------------------------------------------
  * Idempotent upsert of the `header` navigation row + its section
  * anchor items for the `dolcevita` site. Re-runnable safely; if

--- a/scripts/directus/update-brand.mjs
+++ b/scripts/directus/update-brand.mjs
@@ -1,0 +1,354 @@
+#!/usr/bin/env node
+/**
+ * Dolce Vita — targeted brand-rename script (idempotent)
+ * ──────────────────────────────────────────────────────────────────────
+ *
+ * Applies the naming hierarchy from ADR 0002
+ * (.docs/adrs/0002-brand-architecture.md) to existing Directus content:
+ *
+ *   - Parent brand: "Dolce Vita"
+ *   - Offering name: "Dolce Vita Baby Circle"
+ *   - Never "Dolce Vita CT" in customer-facing copy
+ *
+ * Why a separate script (and not `migrate.mjs --seed`)?
+ *   The seed step in migrate.mjs only creates rows on a *fresh* CMS — it
+ *   short-circuits when the homepage already exists. Production CMS already
+ *   has all the rows; we just need to rewrite specific fields. This script
+ *   targets exactly those fields and is safe to run repeatedly: each PATCH
+ *   is guarded by either a "current value matches the OLD value" check or
+ *   an "always-overwrite to the canonical NEW value" pattern, depending on
+ *   the field.
+ *
+ * Usage
+ * ──────
+ *   DIRECTUS_ADMIN_TOKEN=…   node scripts/directus/update-brand.mjs --dry-run
+ *   DIRECTUS_ADMIN_TOKEN=…   node scripts/directus/update-brand.mjs
+ *
+ *   --dry-run   log every PATCH without sending it
+ *   --site=…    site key (default: dolcevita)
+ *
+ * Scope
+ * ──────
+ *   sites                    name, title, description       (always overwrite)
+ *   pages (slug=/)           title, seo_title, seo_descr.   (always overwrite)
+ *   block_hero (homepage)    script_accent → "Dolce Vita"   (always overwrite)
+ *   block_event_details      title (offering naming)        (only if matches OLD)
+ *   block_rsvp_form          consent_copy + success_body    (only if matches OLD)
+ *   block_rich_text rows     known seed copy → new copy     (only if matches OLD)
+ *
+ * Anything not in the scope above is left alone — editors may have already
+ * tuned wording in Directus and we don't want to clobber human edits.
+ */
+
+import { randomUUID } from 'node:crypto';
+import process from 'node:process';
+
+const ARGS = process.argv.slice(2);
+const DRY_RUN = ARGS.includes('--dry-run');
+const SITE_KEY = (ARGS.find((a) => a.startsWith('--site=')) ?? '--site=dolcevita').split('=')[1];
+
+const DIRECTUS_URL = (process.env.DIRECTUS_URL ?? 'https://cms.bravobyte.co').replace(/\/$/, '');
+const ADMIN_TOKEN = process.env.DIRECTUS_ADMIN_TOKEN;
+
+if (!ADMIN_TOKEN) {
+	console.error(
+		'\n✗ DIRECTUS_ADMIN_TOKEN is required.\n  Export it first:\n  DIRECTUS_ADMIN_TOKEN=… node scripts/directus/update-brand.mjs\n'
+	);
+	process.exit(1);
+}
+
+let patchCount = 0;
+let skipCount = 0;
+
+async function api(method, path, body) {
+	if (DRY_RUN && method !== 'GET') {
+		console.log(`  [dry-run] ${method} ${path}`, body ? JSON.stringify(body).slice(0, 240) : '');
+		return { data: { id: randomUUID() } };
+	}
+	const res = await fetch(`${DIRECTUS_URL}${path}`, {
+		method,
+		headers: {
+			Authorization: `Bearer ${ADMIN_TOKEN}`,
+			'Content-Type': 'application/json'
+		},
+		body: body ? JSON.stringify(body) : undefined
+	});
+	const text = await res.text();
+	const json = text ? JSON.parse(text) : null;
+	if (!res.ok) {
+		const message = json?.errors?.[0]?.message ?? text;
+		const err = new Error(`${method} ${path} → ${res.status}: ${message}`);
+		err.status = res.status;
+		err.payload = json;
+		throw err;
+	}
+	return json;
+}
+
+async function findOne(collection, filter, fields = ['id']) {
+	const qs = new URLSearchParams({
+		filter: JSON.stringify(filter),
+		fields: fields.join(','),
+		limit: '1'
+	});
+	const r = await api('GET', `/items/${collection}?${qs}`);
+	return r.data?.[0] ?? null;
+}
+
+async function findMany(collection, filter, fields = ['id'], limit = 100) {
+	const qs = new URLSearchParams({
+		filter: JSON.stringify(filter),
+		fields: fields.join(','),
+		limit: String(limit)
+	});
+	const r = await api('GET', `/items/${collection}?${qs}`);
+	return r.data ?? [];
+}
+
+/**
+ * Always overwrite the listed fields on a row to the canonical brand
+ * values. Use for fields whose only correct value is the canonical one
+ * (titles, SEO strings, brand names).
+ */
+async function overwriteFields(collection, id, patch, label) {
+	console.log(`  → patch ${collection}/${id} (${label})`);
+	for (const [k, v] of Object.entries(patch)) {
+		const display = typeof v === 'string' && v.length > 60 ? `${v.slice(0, 57)}…` : v;
+		console.log(`      ${k} = ${JSON.stringify(display)}`);
+	}
+	await api('PATCH', `/items/${collection}/${id}`, patch);
+	patchCount++;
+}
+
+/**
+ * Patch a row only if every field still has its OLD seeded value (i.e.
+ * an editor hasn't already rewritten it). Protects against clobbering
+ * human edits made directly in Directus.
+ */
+async function rewriteIfPristine(collection, id, current, transitions, label) {
+	const patch = {};
+	const skipped = [];
+	for (const { field, from, to } of transitions) {
+		const cur = current?.[field];
+		if (cur === to) {
+			skipped.push(`${field} (already canonical)`);
+			continue;
+		}
+		if (cur === from) {
+			patch[field] = to;
+		} else {
+			skipped.push(`${field} (edited away from seed; left as-is)`);
+		}
+	}
+	if (Object.keys(patch).length === 0) {
+		console.log(`  ≡ ${collection}/${id} (${label}): nothing to do — ${skipped.join(', ')}`);
+		skipCount++;
+		return;
+	}
+	if (skipped.length) console.log(`  · ${collection}/${id} skipped: ${skipped.join(', ')}`);
+	await overwriteFields(collection, id, patch, label);
+}
+
+// ──────────────────────────────────────────────────────────────────────
+//  Update steps
+// ──────────────────────────────────────────────────────────────────────
+
+async function updateSite() {
+	console.log(`\n· sites (key=${SITE_KEY})`);
+	const site = await findOne('sites', { key: { _eq: SITE_KEY } }, [
+		'id',
+		'name',
+		'title',
+		'description'
+	]);
+	if (!site) {
+		console.error(`  ✗ site "${SITE_KEY}" not found`);
+		process.exit(2);
+	}
+	await overwriteFields(
+		'sites',
+		site.id,
+		{
+			name: 'Dolce Vita',
+			title: 'Dolce Vita Baby Circle',
+			description:
+				'Dolce Vita Baby Circle — an Italian-inspired mama & bambino circle in Stamford, Connecticut. The first chapter of the Dolce Vita brand.'
+		},
+		'parent-brand naming'
+	);
+	return site.id;
+}
+
+async function updateHomepage(siteId) {
+	console.log('\n· pages (slug=/)');
+	const page = await findOne(
+		'pages',
+		{ _and: [{ site: { _eq: siteId } }, { slug: { _eq: '/' } }] },
+		['id', 'title', 'seo_title', 'seo_description', 'blocks.id', 'blocks.collection', 'blocks.item']
+	);
+	if (!page) {
+		console.error('  ✗ homepage row not found; skipping page-scoped updates');
+		return null;
+	}
+	await overwriteFields(
+		'pages',
+		page.id,
+		{
+			title: 'Dolce Vita Baby Circle',
+			seo_title: 'Dolce Vita Baby Circle — Italian-inspired mama & bambino in Stamford, CT',
+			seo_description:
+				'Reserve your spot at the Dolce Vita Baby Circle — a warm, refined Italian-inspired morning for mama and bambino in Stamford, Connecticut. The first chapter of Dolce Vita.'
+		},
+		'homepage SEO'
+	);
+	return page;
+}
+
+async function updateHero(page) {
+	if (!page?.blocks?.length) return;
+	const heroEntry = page.blocks.find((b) => b.collection === 'block_hero');
+	if (!heroEntry) {
+		console.log('\n· block_hero: no hero on homepage; skipping');
+		return;
+	}
+	console.log('\n· block_hero (script accent)');
+	// Some BravoByte sites' `block_hero` shape doesn't include a
+	// `script_accent` field — Dolce Vita's homepage uses the parent-brand
+	// script accent purely in the SvelteKit fallback (`src/routes/(app)/+page.svelte`).
+	// We probe for the field first so the script stays useful across schema variants.
+	let hero;
+	try {
+		hero = await findOne('block_hero', { id: { _eq: heroEntry.item } }, [
+			'id',
+			'script_accent',
+			'headline'
+		]);
+	} catch (err) {
+		const message = err?.payload?.errors?.[0]?.message ?? '';
+		const missingField = err?.status === 403 && /field "script_accent"/.test(message);
+		if (missingField) {
+			console.log(
+				'  ≡ block_hero has no `script_accent` field in this Directus schema — script-accent framing lives only in the SvelteKit fallback (no CMS update needed).'
+			);
+			skipCount++;
+			return;
+		}
+		throw err;
+	}
+	if (!hero) return;
+	if (hero.script_accent !== 'Dolce Vita') {
+		await overwriteFields(
+			'block_hero',
+			hero.id,
+			{ script_accent: 'Dolce Vita' },
+			'parent-brand script accent'
+		);
+	} else {
+		console.log('  ≡ block_hero script_accent already canonical');
+		skipCount++;
+	}
+}
+
+async function updateEventDetails(siteId) {
+	console.log('\n· block_event_details');
+	const rows = await findMany('block_event_details', { site: { _eq: siteId } }, ['id', 'title']);
+	for (const row of rows) {
+		await rewriteIfPristine(
+			'block_event_details',
+			row.id,
+			row,
+			[
+				{
+					field: 'title',
+					from: 'Dolce Vita Baby Circle · Spring Session',
+					to: 'Dolce Vita Baby Circle · Spring Session'
+				}
+			],
+			'event title'
+		);
+	}
+}
+
+async function updateRsvpForm(siteId) {
+	console.log('\n· block_rsvp_form');
+	const rows = await findMany('block_rsvp_form', { site: { _eq: siteId } }, [
+		'id',
+		'success_body',
+		'consent_copy'
+	]);
+	for (const row of rows) {
+		await rewriteIfPristine(
+			'block_rsvp_form',
+			row.id,
+			row,
+			[
+				{
+					field: 'success_body',
+					from: 'Your note is in. Look for an email from hello@dolcevitact.com within a day.',
+					to: 'Your note is in. Look for an email from babycircle@dolcevitact.com within a day.'
+				},
+				{
+					field: 'consent_copy',
+					from: "By reserving you agree to receive a follow-up email from Dolce Vita CT. We don't share your information.",
+					to: "By reserving you agree to receive a follow-up email from the Dolce Vita Baby Circle. We don't share your information."
+				}
+			],
+			'rsvp consent + success copy'
+		);
+	}
+}
+
+async function updateRichText() {
+	console.log('\n· block_rich_text (homepage seed copy)');
+	// We don't site-scope block_rich_text because the collection is shared
+	// across sites and not site-scoped at the schema level. Instead we
+	// match the EXACT seeded HTML, which is unique enough to identify
+	// just the rows that came from migrate.mjs --seed.
+	const transitions = [
+		{
+			from: '<p>Dolce Vita CT is a small, intentional circle for Italian-curious families — a morning of music, language, and movement designed to feel like a Sunday in Liguria.</p>',
+			to: '<p>The Dolce Vita Baby Circle is a small, intentional gathering for Italian-curious families — a morning of music, language, and movement designed to feel like a Sunday in Liguria.</p>'
+		},
+		{
+			from: '<p>Dolce Vita CT exists because raising a child between two languages should feel like a gift, not a chore. Our circles are the opposite of a class — they are small rituals built around the sounds of home.</p>',
+			to: '<p>Dolce Vita exists because raising a child between two languages should feel like a gift, not a chore. Our Baby Circle is the opposite of a class — it is a small ritual built around the sounds of home.</p>'
+		}
+	];
+	for (const { from, to } of transitions) {
+		const matches = await findMany('block_rich_text', { content: { _eq: from } }, ['id']);
+		if (matches.length === 0) {
+			console.log(`  ≡ no rich_text rows match seed snippet (${from.slice(0, 60)}…)`);
+			skipCount++;
+			continue;
+		}
+		for (const row of matches) {
+			await overwriteFields('block_rich_text', row.id, { content: to }, 'rich text rewrite');
+		}
+	}
+}
+
+// ──────────────────────────────────────────────────────────────────────
+//  Main
+// ──────────────────────────────────────────────────────────────────────
+
+async function main() {
+	console.log(`\nDolce Vita — brand rename (${DIRECTUS_URL})`);
+	console.log(`  site key      : ${SITE_KEY}`);
+	console.log(`  mode          : ${DRY_RUN ? 'DRY RUN' : 'LIVE'}\n`);
+
+	const siteId = await updateSite();
+	const page = await updateHomepage(siteId);
+	await updateHero(page);
+	await updateEventDetails(siteId);
+	await updateRsvpForm(siteId);
+	await updateRichText();
+
+	console.log(`\n✓ done. ${patchCount} patch(es), ${skipCount} skipped.`);
+	if (DRY_RUN) console.log('  (dry-run — re-run without --dry-run to apply.)');
+}
+
+main().catch((err) => {
+	console.error('\n✗ failed:', err.message);
+	if (err.payload) console.error(JSON.stringify(err.payload, null, 2));
+	process.exit(1);
+});

--- a/spec.md
+++ b/spec.md
@@ -1,9 +1,11 @@
 # dolcevitact.com — Product Spec
 
-> **Owner:** BravoByteLLC for Dolce Vita CT
-> **Domain:** https://dolcevitact.com
-> **Status:** M2 Directus schema — **complete** (migration applied + verified Apr 21 2026; see [`.docs/operations/m2-verification.md`](./.docs/operations/m2-verification.md)). M4 (sections) is now the active milestone.
-> **Last Updated:** April 21, 2026
+> **Owner:** BravoByteLLC for the Dolce Vita brand
+> **Domain:** https://dolcevitact.com (the `ct` suffix is a domain-availability quirk — the brand is "Dolce Vita")
+> **First chapter:** Dolce Vita Baby Circle
+> **Brand architecture:** branded house, paths-first (see [`.docs/adrs/0002-brand-architecture.md`](./.docs/adrs/0002-brand-architecture.md))
+> **Status:** M5 RSVP intake in review (PR #28). M2 Directus schema complete + verified Apr 21 2026 ([`.docs/operations/m2-verification.md`](./.docs/operations/m2-verification.md)). M4 (sections) split into M4a/b/c — all merged. M6 (Launch) is the next active milestone.
+> **Last Updated:** April 25, 2026
 
 This is the single source of truth for what `dolcevitact-web` is, why it exists,
 and where we are. It must stay under 500 lines and reference detail files
@@ -13,12 +15,18 @@ rather than duplicating them.
 
 ## 1. Project overview
 
-Dolce Vita CT is a premium Italian-inspired mom & baby experience based in
-Stamford, Connecticut. The first offering is **Dolce Vita Baby Circle**, a
-warm, refined class led by a native Italian speaker, teacher, and mom.
+**Dolce Vita** is a premium Italian-inspired lifestyle brand based in Stamford,
+Connecticut. The first chapter is **Dolce Vita Baby Circle**, a warm, refined
+mama-and-bambino class led by a native Italian speaker, teacher, and mom.
+Future chapters under consideration include cucina (homecooked Italian food
+service), online classes, and a newsletter.
 
-`dolcevitact-web` is the marketing single-page application that introduces the
-brand, explains the experience, and converts visitors into RSVPs.
+`dolcevitact-web` is the marketing single-page application that launches the
+brand, introduces the Baby Circle, and converts visitors into RSVPs. It is
+architected as a branded-house portal: the homepage currently _is_ the Baby
+Circle; new offerings will live at sibling paths (`/cucina`, `/classes`, etc.)
+on the same domain rather than as separate sites — see
+[`.docs/adrs/0002-brand-architecture.md`](./.docs/adrs/0002-brand-architecture.md).
 
 **Tech stack:** SvelteKit 2 (Svelte 5 runes) · TypeScript · Tailwind v4 ·
 Vitest · Playwright · Directus (shared multi-site, key `dolcevita`) ·
@@ -86,7 +94,7 @@ The homepage is a single Directus `pages` row composed of M2A blocks:
 | M5  | RSVP                     | in progress | [#6](https://github.com/BravoByte-org/dolcevitact-web/milestone/6) | `?/rsvp` form action → Zod validate → Directus `rsvp_submissions` write → Resend notification + honeypot + success/error UI. Plan: [`.docs/architecture/m5-rsvp-plan.md`](./.docs/architecture/m5-rsvp-plan.md) |
 | M6  | Launch                   | planned     | [#7](https://github.com/BravoByte-org/dolcevitact-web/milestone/7) | SEO, a11y, deploy                                                                                                                                                                                               |
 
-GitHub Project board: [BravoByte/Dolce Vita CT Board](https://github.com/orgs/BravoByte-org/projects/4)
+GitHub Project board: [BravoByte/Dolce Vita Board](https://github.com/orgs/BravoByte-org/projects/4)
 
 ---
 
@@ -110,10 +118,21 @@ Full design notes: `.docs/architecture/design-system.md` (added in M3).
 - Testimonials block
 - Blog / journal
 - Bilingual EN/IT (Directus translations layer — structural change not required)
+- Sibling brand chapters (cucina, online classes, newsletter) — covered by
+  Phase 2 of the brand-architecture ADR; ship after Baby Circle proves out.
 
 ---
 
-## 8. Operational links
+## 8. Architecture decisions
+
+| ADR  | Title                                                                                     | Status   |
+| ---- | ----------------------------------------------------------------------------------------- | -------- |
+| 0001 | [Dolce Vita delivery architecture](./.docs/adrs/0001-dolce-vita-architecture.md)          | Accepted |
+| 0002 | [Brand architecture: branded house, paths-first](./.docs/adrs/0002-brand-architecture.md) | Accepted |
+
+---
+
+## 9. Operational links
 
 | Resource            | URL                                              |
 | ------------------- | ------------------------------------------------ |

--- a/src/lib/components/blocks/RsvpFormBlock.svelte
+++ b/src/lib/components/blocks/RsvpFormBlock.svelte
@@ -78,7 +78,7 @@
 				{#if hasServerError}
 					<p class="dv-rsvp__alert" role="alert">
 						Something interrupted us on our side. Please try again in a moment — or email
-						hello@dolcevitact.com and we'll get you on the list.
+						babycircle@dolcevitact.com and we'll get you on the list.
 					</p>
 				{/if}
 

--- a/src/lib/components/navigation/SiteFooter.svelte
+++ b/src/lib/components/navigation/SiteFooter.svelte
@@ -6,10 +6,10 @@
 
 	let {
 		items = [],
-		siteTitle = 'Dolce Vita CT',
-		contactEmail = 'hello@dolcevitact.com',
+		siteTitle = 'Dolce Vita Baby Circle',
+		contactEmail = 'babycircle@dolcevitact.com',
 		cityLine = 'Stamford, Connecticut',
-		tagline = 'An Italian-inspired circle for mothers and babies.'
+		tagline = 'An Italian-inspired circle for mothers and babies — the first chapter of Dolce Vita.'
 	}: {
 		items?: NavItem[];
 		siteTitle?: string;

--- a/src/lib/components/navigation/SiteNav.svelte
+++ b/src/lib/components/navigation/SiteNav.svelte
@@ -5,7 +5,7 @@
 
 	let {
 		items = [],
-		siteTitle = 'Dolce Vita CT',
+		siteTitle = 'Dolce Vita Baby Circle',
 		ctaLabel = 'Reserve',
 		ctaHref = '#rsvp'
 	}: {

--- a/src/lib/server/directus.ts
+++ b/src/lib/server/directus.ts
@@ -9,7 +9,7 @@ import {
 import { env } from '$env/dynamic/private';
 
 /**
- * Typed schema for the Dolce Vita CT view of the shared BravoByte Directus
+ * Typed schema for the Dolce Vita view of the shared BravoByte Directus
  * instance at https://cms.bravobyte.co. Only collections this delivery app
  * actually reads are declared — everything else goes through the SDK as
  * `Record<string, unknown>` which we never rely on.

--- a/src/lib/server/email.ts
+++ b/src/lib/server/email.ts
@@ -47,7 +47,7 @@ export async function sendRsvpNotification(payload: RsvpNotification): Promise<S
 	if (!resend) return { sent: false, reason: 'disabled' };
 
 	const to = env.RSVP_NOTIFY_EMAIL;
-	const from = env.RSVP_NOTIFY_FROM || 'Dolce Vita CT <reservations@dolcevitact.com>';
+	const from = env.RSVP_NOTIFY_FROM || 'Dolce Vita Baby Circle <reservations@ciao.dolcevitact.com>';
 	if (!to) {
 		console.warn('[email] RSVP_NOTIFY_EMAIL not set — skipping email notification.');
 		return { sent: false, reason: 'misconfigured' };
@@ -101,7 +101,7 @@ function renderNotificationHtml(p: RsvpNotification): string {
 		<table role="presentation" cellpadding="0" cellspacing="0" style="max-width:560px;margin:0 auto;background:#fffbf6;border:1px solid #e7ddcf;border-radius:12px;padding:32px;">
 			<tr>
 				<td>
-					<p style="margin:0 0 4px;font-family:Georgia,serif;font-size:12px;letter-spacing:0.18em;text-transform:uppercase;color:#a07a4d;">Dolce Vita CT</p>
+					<p style="margin:0 0 4px;font-family:Georgia,serif;font-size:12px;letter-spacing:0.18em;text-transform:uppercase;color:#a07a4d;">Dolce Vita Baby Circle</p>
 					<h1 style="margin:0 0 24px;font-family:Georgia,serif;font-size:26px;font-weight:400;color:#2d2a26;">New RSVP received</h1>
 					<table role="presentation" cellpadding="0" cellspacing="0">
 						${renderRow('Name', p.name)}
@@ -122,7 +122,7 @@ function renderNotificationHtml(p: RsvpNotification): string {
 
 function renderNotificationText(p: RsvpNotification): string {
 	const lines = [
-		'New RSVP received — Dolce Vita CT',
+		'New RSVP received — Dolce Vita Baby Circle',
 		'',
 		`Name:       ${p.name}`,
 		`Email:      ${p.email}`,

--- a/src/lib/styles/tokens.css
+++ b/src/lib/styles/tokens.css
@@ -1,5 +1,5 @@
 /*
- * Dolce Vita CT — design tokens
+ * Dolce Vita — design tokens
  * --------------------------------------------------------------
  * The brand palette is intentionally restrained: warm ivory paper,
  * earthy terracotta, muted sage, sand taupe, restrained gold accents,

--- a/src/routes/(app)/+layout.svelte
+++ b/src/routes/(app)/+layout.svelte
@@ -12,16 +12,16 @@
 	const site = $derived(
 		(data.site as { title?: string | null; description?: string | null } | null) ?? null
 	);
-	const siteTitle = $derived(site?.title ?? 'Dolce Vita CT');
+	const siteTitle = $derived(site?.title ?? 'Dolce Vita Baby Circle');
 	const navItems = $derived(((data.navigation ?? []) as NavItem[]) ?? []);
 </script>
 
 <svelte:head>
-	<title>{siteTitle} — Italian-inspired mom & baby experience in Stamford, CT</title>
+	<title>{siteTitle} — Italian-inspired mama & bambino circle in Stamford, CT</title>
 	<meta
 		name="description"
 		content={site?.description ??
-			'Dolce Vita CT is a premium Italian-inspired mom & baby experience in Stamford, Connecticut. Reserve your spot at the Dolce Vita Baby Circle.'}
+			'Dolce Vita Baby Circle — an Italian-inspired morning of music, language, and movement for mama and bambino in Stamford, Connecticut. The first chapter of Dolce Vita.'}
 	/>
 	<link rel="canonical" href="https://dolcevitact.com/" />
 	<meta property="og:type" content="website" />

--- a/src/routes/(app)/+page.svelte
+++ b/src/routes/(app)/+page.svelte
@@ -14,16 +14,16 @@
 	const seoTitle = $derived(
 		(page?.seo_title as string | undefined) ??
 			(page?.title as string | undefined) ??
-			'Dolce Vita CT'
+			'Dolce Vita Baby Circle'
 	);
 	const seoDescription = $derived(
 		(page?.seo_description as string | undefined) ??
-			'A premium Italian-inspired mom & baby experience in Stamford, CT.'
+			'An Italian-inspired morning for mama and bambino in Stamford, CT — the first chapter of Dolce Vita.'
 	);
 </script>
 
 <svelte:head>
-	<title>{seoTitle} | Dolce Vita CT</title>
+	<title>{seoTitle} | Dolce Vita Baby Circle</title>
 	<meta name="description" content={seoDescription} />
 </svelte:head>
 
@@ -33,7 +33,9 @@
 	<!--
 		Fallback: if Directus is unreachable or the seeded page hasn't landed
 		yet, render the M3 editorial placeholder so production never shows a
-		blank page on a CMS hiccup.
+		blank page on a CMS hiccup. The script accent uses the parent brand
+		("Dolce Vita") with the offering name in the headline below — matches
+		the branded-house framing recorded in ADR 0002.
 	-->
 	<section class="dv-fallback">
 		<div class="dv-fallback__inner">
@@ -41,18 +43,19 @@
 			<div class="dv-fallback__olive">
 				<OliveBranch tone="sage" />
 			</div>
-			<p class="dv-script mt-2">Dolce Vita CT</p>
+			<p class="dv-script mt-2">Dolce Vita</p>
 			<h1 class="dv-h1 dv-anim-rise mt-4 text-balance">
-				An Italian-inspired moment for mama e bambino
+				An Italian-inspired morning for mama e bambino
 			</h1>
 			<div class="mt-6">
 				<GoldRule size="md" />
 			</div>
 			<p class="dv-lede dv-anim-rise mx-auto mt-8 text-balance">
-				A warm, refined Italian circle for mothers and babies — coming this spring in Stamford.
+				The Baby Circle — a warm, refined Italian circle for mothers and babies, coming this spring
+				in Stamford.
 			</p>
 			<a
-				href="mailto:hello@dolcevitact.com?subject=Dolce%20Vita%20CT%20early%20list"
+				href="mailto:babycircle@dolcevitact.com?subject=Dolce%20Vita%20Baby%20Circle%20early%20list"
 				class="dv-fallback__cta">Be the first to know</a
 			>
 		</div>


### PR DESCRIPTION
## Summary

PR #29 (the brand rename) was merged into `feat/m5-rsvp-action` on Apr 25, but `feat/m5-rsvp-action` was already merged into `next` four days earlier via PR #28 — so the rename is currently **stranded** on a dead branch and never made it to `next` (or `main`).

This PR cherry-picks #29's squash commit (`f567b95`) onto a fresh branch off `next` so the rename actually ships. Same diff, same review, just on the right base.

## Why this happened

- PR #29 was opened with `feat/m5-rsvp-action` as its base because it was logically stacked on top of M5.
- Standard stacked-PR workflow expects you to re-target the stacked PR to the new mainline once the base merges. Re-targeting didn't happen, so when #29 merged it landed on the (already-merged) base branch instead of `next`.
- Result: live preview/prod still shows old "Dolce Vita CT" copy in the SvelteKit-side fallbacks, default props, email template, and docs — only the **CMS side** is canonical (via `update-brand.mjs` against prod).

## What's in this PR

Identical to #29:

- Customer-facing copy (layout, page, nav, footer, RSVP block, email)
- ADR 0001 revision + ADR 0002 (NEW — branded house, paths-first)
- `scripts/directus/update-brand.mjs` (NEW, idempotent CMS rename — already executed against prod, see `ciao.dolcevitact.com` Resend setup)
- Internal docs (README, spec, .ai, .cursor, package.json, header comments)
- `migrate.mjs` seed copy made canonical for fresh installs

## Verification

The cherry-pick was clean (no conflicts) — `feat/m5-rsvp-action` was already rebased on `next` before #29's squash.

- [x] `git cherry-pick f567b95` clean
- [ ] CI green (will run on push)
- [ ] Vercel preview shows "Dolce Vita Baby Circle" framing end-to-end (this is the QA pass that should have happened on #29 originally)

## After merge

Delete `fix/m5-brand-rename-promote` branch. Then we're clear to start M6 Launch (SEO, a11y, Lighthouse, DNS) — and tackle the deferred logo polish issue (separate ticket).

Made with [Cursor](https://cursor.com)