### PR TITLE
feat(brand): canonical Dolce Vita / Baby Circle lockup (closes #32)

### DIFF
--- a/.docs/architecture/brand-logo-spec.md
+++ b/.docs/architecture/brand-logo-spec.md
@@ -100,14 +100,14 @@ DOLCE VITA — HEADER & FOOTER RULES
 When porting the spec into the SvelteKit nav / footer / hero, treat it as
 ratios anchored to the "Dolce Vita" baseline:
 
-| Token            | Reference (1024×1536) | Ratio to title baseline | Code intent                                                |
-| ---------------- | --------------------- | ----------------------- | ---------------------------------------------------------- |
-| Dolce Vita size  | 52 px                 | 1.0×                    | Hero: full size · Nav: ~24–28 px · Footer: ~32–40 px       |
-| Baby Circle size | 26 px                 | 0.5×                    | Always exactly half the rendered title size                |
-| Title→subtitle   | 8 px                  | 0.154×                  | Use `clamp()` keyed off `--dv-lockup-size`                 |
-| Subtitle→divider | 12 px                 | 0.231×                  | Same                                                       |
-| Divider→content  | 32 px                 | 0.615×                  | Wrapper margin, not the mark itself                        |
-| Top margin       | 40 px                 | 0.769×                  | Hero shell only — irrelevant in nav (nav has its own pad)  |
+| Token            | Reference (1024×1536) | Ratio to title baseline | Code intent                                               |
+| ---------------- | --------------------- | ----------------------- | --------------------------------------------------------- |
+| Dolce Vita size  | 52 px                 | 1.0×                    | Hero: full size · Nav: ~24–28 px · Footer: ~32–40 px      |
+| Baby Circle size | 26 px                 | 0.5×                    | Always exactly half the rendered title size               |
+| Title→subtitle   | 8 px                  | 0.154×                  | Use `clamp()` keyed off `--dv-lockup-size`                |
+| Subtitle→divider | 12 px                 | 0.231×                  | Same                                                      |
+| Divider→content  | 32 px                 | 0.615×                  | Wrapper margin, not the mark itself                       |
+| Top margin       | 40 px                 | 0.769×                  | Hero shell only — irrelevant in nav (nav has its own pad) |
 
 The "1.0× / 0.5× ratio" is the only inviolable rule. Spacing units scale with
 the title. Build a CSS custom property (`--dv-lockup-size`) and derive
@@ -120,12 +120,12 @@ everything from it so a single value drives nav/footer/hero variants.
 The spec uses informal color names; the existing M3 design system already has
 the right tokens. Map them as follows in the lockup component:
 
-| Spec color           | Token (`src/lib/styles/tokens.css`) | Notes                                    |
-| -------------------- | ----------------------------------- | ---------------------------------------- |
-| terracotta (title)   | `--dv-color-terracotta`             | Already used for accents                 |
-| muted green (script) | `--dv-color-sage` (verify shade)    | Confirm matches "muted green" in poster  |
-| divider line         | `--dv-color-gold` (low-opacity)     | Existing `GoldRule` decorative           |
-| heart                | `--dv-color-terracotta`             | Same as title for color anchoring        |
+| Spec color           | Token (`src/lib/styles/tokens.css`) | Notes                                   |
+| -------------------- | ----------------------------------- | --------------------------------------- |
+| terracotta (title)   | `--dv-color-terracotta`             | Already used for accents                |
+| muted green (script) | `--dv-color-sage` (verify shade)    | Confirm matches "muted green" in poster |
+| divider line         | `--dv-color-gold` (low-opacity)     | Existing `GoldRule` decorative          |
+| heart                | `--dv-color-terracotta`             | Same as title for color anchoring       |
 
 Visual QA pass on the poster against the live tokens may require tuning the
 sage shade or introducing a `--dv-color-sage-soft` token — capture in the
@@ -135,10 +135,10 @@ implementation PR, not here.
 
 ## Typography
 
-| Element     | Family (current)      | Notes                                                       |
-| ----------- | --------------------- | ----------------------------------------------------------- |
-| Dolce Vita  | Cormorant Garamond    | Already loaded via `app.css`. Weight 500 reads closest to poster. |
-| Baby Circle | Tangerine             | Already loaded. Weight 700 (the bolder cut) for legibility at small sizes. |
+| Element     | Family (current)       | Notes                                                                                                     |
+| ----------- | ---------------------- | --------------------------------------------------------------------------------------------------------- |
+| Dolce Vita  | Cormorant Garamond     | Already loaded via `app.css`. Weight 500 reads closest to poster.                                         |
+| Baby Circle | Tangerine              | Already loaded. Weight 700 (the bolder cut) for legibility at small sizes.                                |
 | Heart glyph | inline SVG (preferred) | Avoid emoji `♥` — ships inconsistent across OS. Build a small SVG matching the poster's terracotta heart. |
 
 ---
@@ -147,12 +147,12 @@ implementation PR, not here.
 
 Tracked so the implementation PR can find every site:
 
-| File                                                  | Today                                              | Pre-launch action                                   |
-| ----------------------------------------------------- | -------------------------------------------------- | --------------------------------------------------- |
-| `src/lib/components/navigation/SiteNav.svelte`        | Plain text `siteTitle` prop                        | Replace with `<BrandLockup variant="nav" />`        |
-| `src/lib/components/navigation/SiteFooter.svelte`     | Plain text `siteTitle` prop                        | Replace with `<BrandLockup variant="footer" />`    |
-| `src/routes/(app)/+page.svelte` (hero fallback)       | Stacked `dv-script "Dolce Vita"` + `dv-h1` headline | Replace with `<BrandLockup variant="hero" />`       |
-| `src/lib/components/blocks/HeroBlock.svelte`          | CMS-driven hero                                    | Decide: render `BrandLockup` ABOVE the headline, or only when CMS provides `script_accent` (currently not in schema). |
+| File                                              | Today                                               | Pre-launch action                                                                                                     |
+| ------------------------------------------------- | --------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| `src/lib/components/navigation/SiteNav.svelte`    | Plain text `siteTitle` prop                         | Replace with `<BrandLockup variant="nav" />`                                                                          |
+| `src/lib/components/navigation/SiteFooter.svelte` | Plain text `siteTitle` prop                         | Replace with `<BrandLockup variant="footer" />`                                                                       |
+| `src/routes/(app)/+page.svelte` (hero fallback)   | Stacked `dv-script "Dolce Vita"` + `dv-h1` headline | Replace with `<BrandLockup variant="hero" />`                                                                         |
+| `src/lib/components/blocks/HeroBlock.svelte`      | CMS-driven hero                                     | Decide: render `BrandLockup` ABOVE the headline, or only when CMS provides `script_accent` (currently not in schema). |
 
 A new component `src/lib/components/brand/BrandLockup.svelte` (with three
 variants — `nav`, `footer`, `hero`) is the proposed implementation surface.

--- a/src/lib/components/blocks/HeroBlock.svelte
+++ b/src/lib/components/blocks/HeroBlock.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import BrandLockup from '$components/brand/BrandLockup.svelte';
 	import GoldRule from '$components/decor/GoldRule.svelte';
 	import OliveBranch from '$components/decor/OliveBranch.svelte';
 
@@ -24,6 +25,15 @@
 
 		<div class="dv-hero__olive" aria-hidden="true">
 			<OliveBranch tone="sage" />
+		</div>
+
+		<!--
+			Canonical brand lockup sits above the page H1. The lockup is the
+			brand identity; the H1 below remains the descriptive headline.
+			See `.docs/architecture/brand-logo-spec.md`.
+		-->
+		<div class="dv-hero__lockup">
+			<BrandLockup variant="hero" />
 		</div>
 
 		{#if data.headline}
@@ -63,8 +73,12 @@
 		@apply mx-auto mt-8 w-48 sm:w-56;
 	}
 
+	.dv-hero__lockup {
+		@apply mt-8 flex justify-center;
+	}
+
 	.dv-hero__headline {
-		@apply text-balance;
+		@apply mt-10 text-balance;
 	}
 
 	.dv-hero__rule {

--- a/src/lib/components/brand/BrandLockup.svelte
+++ b/src/lib/components/brand/BrandLockup.svelte
@@ -1,0 +1,158 @@
+<script lang="ts">
+	/**
+	 * BrandLockup — canonical Dolce Vita / Baby Circle stacked mark.
+	 *
+	 *     Dolce Vita        ← serif, terracotta (1.0×)
+	 *     Baby Circle       ← script, muted sage (0.5×)
+	 *     ─── ♥ ───         ← thin gold rule + small terracotta heart
+	 *
+	 * Implements the verbatim founder spec captured in
+	 * `.docs/architecture/brand-logo-spec.md` (closes #32).
+	 *
+	 * The 1.0× / 0.5× ratio between title and subtitle is the only
+	 * inviolable rule. All other sizes — gaps, divider, heart — are
+	 * derived from a single `--dv-lockup-size` custom property so the
+	 * three variants below render in lockstep.
+	 *
+	 * Variants
+	 * --------
+	 *  nav     Compact left/right-alignable mark for the sticky header.
+	 *  footer  Mid-size centred mark for the footer brand block.
+	 *  hero    Full-size centred mark for the hero / fallback hero.
+	 *
+	 * Accessibility
+	 * -------------
+	 * The visible text ("Dolce Vita" + "Baby Circle") is the accessible
+	 * name — screen readers read it naturally as a phrase. The divider
+	 * and heart are decorative (`aria-hidden`). Crawlers still see the
+	 * brand text as plain DOM text, which keeps SEO simple.
+	 */
+
+	type Variant = 'nav' | 'footer' | 'hero';
+
+	type Props = {
+		variant?: Variant;
+		title?: string;
+		subtitle?: string;
+		/** Optional element override for the wrapper. Defaults to `div`. */
+		as?: 'div' | 'span' | 'p';
+		class?: string;
+	};
+
+	let {
+		variant = 'hero',
+		title = 'Dolce Vita',
+		subtitle = 'Baby Circle',
+		as = 'div',
+		class: extraClass = ''
+	}: Props = $props();
+</script>
+
+<svelte:element this={as} class="dv-lockup dv-lockup--{variant} {extraClass}">
+	<span class="dv-lockup__title">{title}</span>
+	<span class="dv-lockup__subtitle">{subtitle}</span>
+	<span class="dv-lockup__divider" aria-hidden="true">
+		<span class="dv-lockup__rule"></span>
+		<svg class="dv-lockup__heart" viewBox="0 0 24 24" role="presentation" focusable="false">
+			<path
+				fill="currentColor"
+				d="M12 21s-7-4.35-9.5-9.1C.9 8.6 2.7 5 6.4 5c2 0 3.4 1.05 5.6 3.2C14.2 6.05 15.6 5 17.6 5 21.3 5 23.1 8.6 21.5 11.9 19 16.65 12 21 12 21z"
+			/>
+		</svg>
+		<span class="dv-lockup__rule"></span>
+	</span>
+</svelte:element>
+
+<style>
+	/*
+	 * The lockup is built around a single sizing custom property:
+	 * --dv-lockup-size sets the title font-size; everything else
+	 * (subtitle, gaps, divider width, heart size) derives from it
+	 * via em / fixed ratios. Variants only override --dv-lockup-size.
+	 */
+	.dv-lockup {
+		display: inline-flex;
+		flex-direction: column;
+		align-items: center;
+		gap: 0;
+		line-height: 1;
+		color: var(--dv-color-charcoal);
+	}
+
+	/* Variants — only the sizing knob changes per context */
+	.dv-lockup--nav {
+		--dv-lockup-size: clamp(1.4rem, 1rem + 0.6vw, 1.6rem);
+	}
+
+	.dv-lockup--footer {
+		--dv-lockup-size: clamp(1.9rem, 1.3rem + 1vw, 2.4rem);
+	}
+
+	.dv-lockup--hero {
+		--dv-lockup-size: clamp(3rem, 2rem + 3vw, 4.5rem);
+	}
+
+	.dv-lockup__title {
+		font-family: var(--dv-font-display);
+		font-weight: 500;
+		font-size: var(--dv-lockup-size);
+		line-height: 1;
+		letter-spacing: 0.01em;
+		color: var(--dv-color-terracotta);
+	}
+
+	/* Subtitle is locked at exactly half the title baseline (1.0× / 0.5×). */
+	.dv-lockup__subtitle {
+		font-family: var(--dv-font-script);
+		font-weight: 700;
+		font-size: calc(var(--dv-lockup-size) * 0.5);
+		line-height: 1;
+		color: var(--dv-color-sage-deep);
+		/* Title → subtitle gap: 8px @ 52px baseline = 0.154em of title. */
+		margin-top: calc(var(--dv-lockup-size) * 0.154);
+	}
+
+	.dv-lockup__divider {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		gap: calc(var(--dv-lockup-size) * 0.18);
+		/* Subtitle → divider gap: 12px @ 52px baseline = 0.231em of title. */
+		margin-top: calc(var(--dv-lockup-size) * 0.231);
+		/* Total divider width — modest by design, never spans the full title. */
+		width: calc(var(--dv-lockup-size) * 2.4);
+	}
+
+	.dv-lockup__rule {
+		flex: 1 1 auto;
+		height: 1px;
+		background: linear-gradient(
+			to right,
+			transparent 0%,
+			color-mix(in srgb, var(--dv-color-gold) 70%, transparent) 30%,
+			color-mix(in srgb, var(--dv-color-gold) 70%, transparent) 70%,
+			transparent 100%
+		);
+	}
+
+	.dv-lockup__heart {
+		flex: 0 0 auto;
+		width: calc(var(--dv-lockup-size) * 0.28);
+		height: calc(var(--dv-lockup-size) * 0.28);
+		color: var(--dv-color-terracotta);
+	}
+
+	/*
+	 * Honor reduced-motion: nothing here animates today, but if a parent
+	 * adds an entrance animation we want this mark to remain stable.
+	 */
+	@media (prefers-reduced-motion: reduce) {
+		.dv-lockup,
+		.dv-lockup__title,
+		.dv-lockup__subtitle,
+		.dv-lockup__divider {
+			animation: none !important;
+			transition: none !important;
+		}
+	}
+</style>

--- a/src/lib/components/navigation/SiteFooter.svelte
+++ b/src/lib/components/navigation/SiteFooter.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { base } from '$app/paths';
+	import BrandLockup from '$components/brand/BrandLockup.svelte';
 	import GoldRule from '$components/decor/GoldRule.svelte';
 	import OliveBranch from '$components/decor/OliveBranch.svelte';
 	import type { NavItem, NavChild } from './types';
@@ -48,7 +49,9 @@
 			<div class="dv-footer__olive" aria-hidden="true">
 				<OliveBranch tone="sage" />
 			</div>
-			<p class="dv-footer__script">{siteTitle}</p>
+			<div class="dv-footer__lockup">
+				<BrandLockup variant="footer" />
+			</div>
 			<p class="dv-footer__tagline">{tagline}</p>
 		</div>
 
@@ -127,11 +130,15 @@
 		}
 	}
 
-	.dv-footer__script {
-		font-family: var(--dv-font-script);
-		font-size: clamp(2.5rem, 1.6rem + 2vw, 3.5rem);
-		color: var(--dv-color-terracotta-deep);
-		line-height: 1;
+	.dv-footer__lockup {
+		display: flex;
+		justify-content: center;
+	}
+
+	@media (min-width: 720px) {
+		.dv-footer__lockup {
+			justify-content: flex-start;
+		}
 	}
 
 	.dv-footer__tagline {

--- a/src/lib/components/navigation/SiteNav.svelte
+++ b/src/lib/components/navigation/SiteNav.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { base } from '$app/paths';
+	import BrandLockup from '$components/brand/BrandLockup.svelte';
 	import HamburgerButton from './HamburgerButton.svelte';
 	import type { NavItem, NavChild } from './types';
 
@@ -100,8 +101,8 @@
 
 <header class="dv-nav" class:dv-nav--scrolled={scrolled}>
 	<div class="dv-nav__bar">
-		<a href="/" class="dv-nav__brand" onclick={closeMobile}>
-			<span class="dv-nav__brand-script">{siteTitle}</span>
+		<a href="/" class="dv-nav__brand" onclick={closeMobile} aria-label={siteTitle}>
+			<BrandLockup variant="nav" />
 		</a>
 
 		<nav class="dv-nav__desktop" aria-label="Primary">
@@ -141,7 +142,9 @@
 	bind:this={panelRef}
 >
 	<div class="dv-nav__panel-inner">
-		<p class="dv-nav__panel-brand dv-script">{siteTitle}</p>
+		<div class="dv-nav__panel-brand">
+			<BrandLockup variant="footer" />
+		</div>
 
 		<ul class="dv-nav__panel-list">
 			{#each inlineItems as item (item.id)}
@@ -200,15 +203,16 @@
 	}
 
 	.dv-nav__brand {
+		display: inline-flex;
+		align-items: center;
 		color: var(--dv-color-charcoal);
 		text-decoration: none;
+		border-radius: 4px;
 	}
 
-	.dv-nav__brand-script {
-		font-family: var(--dv-font-script);
-		font-size: clamp(1.75rem, 1.2rem + 1vw, 2.25rem);
-		line-height: 1;
-		color: var(--dv-color-terracotta-deep);
+	.dv-nav__brand:focus-visible {
+		outline: 2px solid var(--dv-color-terracotta-deep);
+		outline-offset: 6px;
 	}
 
 	.dv-nav__desktop {
@@ -331,8 +335,8 @@
 	}
 
 	.dv-nav__panel-brand {
-		font-size: clamp(3rem, 2rem + 3vw, 4rem);
-		color: var(--dv-color-terracotta-deep);
+		display: flex;
+		justify-content: center;
 		margin-bottom: 2.5rem;
 	}
 

--- a/src/routes/(app)/+page.svelte
+++ b/src/routes/(app)/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import type { PageData } from './$types';
 	import BlockRenderer from '$components/blocks/BlockRenderer.svelte';
+	import BrandLockup from '$components/brand/BrandLockup.svelte';
 	import GoldRule from '$components/decor/GoldRule.svelte';
 	import OliveBranch from '$components/decor/OliveBranch.svelte';
 	import type { Block } from '$components/blocks/types';
@@ -33,9 +34,9 @@
 	<!--
 		Fallback: if Directus is unreachable or the seeded page hasn't landed
 		yet, render the M3 editorial placeholder so production never shows a
-		blank page on a CMS hiccup. The script accent uses the parent brand
-		("Dolce Vita") with the offering name in the headline below — matches
-		the branded-house framing recorded in ADR 0002.
+		blank page on a CMS hiccup. The canonical Dolce Vita / Baby Circle
+		lockup carries the brand identity; the H1 below remains the page's
+		descriptive headline (one H1 per page, brand mark stays decorative).
 	-->
 	<section class="dv-fallback">
 		<div class="dv-fallback__inner">
@@ -43,8 +44,10 @@
 			<div class="dv-fallback__olive">
 				<OliveBranch tone="sage" />
 			</div>
-			<p class="dv-script mt-2">Dolce Vita</p>
-			<h1 class="dv-h1 dv-anim-rise mt-4 text-balance">
+			<div class="dv-fallback__lockup">
+				<BrandLockup variant="hero" />
+			</div>
+			<h1 class="dv-h1 dv-anim-rise mt-8 text-balance">
 				An Italian-inspired morning for mama e bambino
 			</h1>
 			<div class="mt-6">
@@ -77,6 +80,12 @@
 		margin-inline: auto;
 		margin-top: 2rem;
 		width: 12rem;
+	}
+
+	.dv-fallback__lockup {
+		display: flex;
+		justify-content: center;
+		margin-top: 1.5rem;
 	}
 
 	.dv-fallback__cta {


### PR DESCRIPTION
## Summary

Implements the canonical Dolce Vita / Baby Circle brand lockup specified in [`.docs/architecture/brand-logo-spec.md`](https://github.com/BravoByte-org/dolcevitact-web/blob/feat/m6-brand-lockup/.docs/architecture/brand-logo-spec.md) (PR #31), replacing the placeholder text marks across the site.

```
Dolce Vita        ← serif, terracotta (1.0×)
Baby Circle       ← script, muted sage (0.5×)
─── ♥ ───         ← thin gold rule + small terracotta heart
```

Closes #32.

## What changed

**New component**

- `src/lib/components/brand/BrandLockup.svelte` — single source of truth for the mark. Three variants (`nav`, `footer`, `hero`) driven by a single \`--dv-lockup-size\` custom property. The 1.0× / 0.5× ratio between title and subtitle is enforced; gaps scale with the title baseline (e.g. 8 px @ 52 px = 0.154em title→subtitle).

**Wired in**

| File | Before | After |
| --- | --- | --- |
| `SiteNav.svelte` (header brand link) | inline \`dv-nav__brand-script\` text | `<BrandLockup variant="nav" />` |
| `SiteNav.svelte` (mobile drawer brand) | inline \`dv-script\` text | `<BrandLockup variant="footer" />` (drawer reads as a mid-size lockup) |
| `SiteFooter.svelte` (brand column) | inline \`dv-footer__script\` text | `<BrandLockup variant="footer" />` |
| `HeroBlock.svelte` (CMS hero) | headline-only | `<BrandLockup variant="hero" />` above the H1 |
| `(app)/+page.svelte` (hero fallback) | inline \`dv-script "Dolce Vita"\` | `<BrandLockup variant="hero" />` above the H1 |

**Hero decision (called out in spec doc)** — the spec doc flagged HeroBlock as a decision point ("render lockup ABOVE the headline, or only when CMS provides \`script_accent\`"). Chose **render unconditionally above the H1** since (a) \`script_accent\` doesn't exist in the live Directus schema for Dolce Vita, and (b) the canonical hero moment is exactly where the brand mark belongs. Easy to revert to conditional if QA prefers.

## Design fidelity to the founder spec

| Spec rule | Implementation |
| --- | --- |
| Title : subtitle = 1.0× : 0.5× (inviolable) | Hardcoded \`calc(var(--dv-lockup-size) * 0.5)\` |
| Title→subtitle gap 8 px @ 52 px baseline (0.154×) | \`calc(var(--dv-lockup-size) * 0.154)\` |
| Subtitle→divider gap 12 px @ 52 px (0.231×) | \`calc(var(--dv-lockup-size) * 0.231)\` |
| Title: serif, terracotta | Cormorant Garamond, weight 500, \`--dv-color-terracotta\` |
| Subtitle: script, muted green | Tangerine, weight 700, \`--dv-color-sage-deep\` |
| Divider: thin line + small heart, centered | Two gold gradient hairlines flanking an inline-SVG heart in \`--dv-color-terracotta\` |
| Layout order locked: title → subtitle → divider | Stack order in markup; \`flex-direction: column align-items: center\` |

No new color tokens were introduced — sage / terracotta / gold are all from the M3 design system.

## Accessibility

- Visible text remains plain DOM text — screen readers read "Dolce Vita Baby Circle" naturally; crawlers see the brand text for SEO.
- Divider rule + heart SVG are \`aria-hidden\` (purely decorative).
- The header brand link gets an explicit \`aria-label={siteTitle}\` for the link's accessible name (since the visible text inside is now a multi-element lockup).
- Honors \`prefers-reduced-motion\`.

## Test plan

- [x] Local: \`pnpm format\` / \`pnpm lint\` / \`pnpm check\` / \`pnpm test\` / \`pnpm build\` — all green.
- [ ] CI: confirm bravobyte-platform reusable workflow passes on this PR.
- [ ] Vercel preview deploy:
  - [ ] Header lockup centered + readable at all breakpoints (≥1280, ~840 desktop/mobile transition, ~360 mobile).
  - [ ] Mobile drawer brand block renders the larger \`footer\` variant (drawer is a full-screen panel; the mid-size mark suits it).
  - [ ] Footer brand block sits left-aligned at ≥720 px, centred at <720 px (matching the existing footer responsive grid).
  - [ ] Hero (production data via CMS) — lockup sits above the H1 headline, with the H1 as the page H1 (still the only H1 on the page).
  - [ ] Hero fallback (force a CMS error in dev to verify) — same lockup placement.
  - [ ] Heart SVG fills with terracotta on all browsers (no emoji fallback).
  - [ ] Sage colour reads as "muted green" against the poster reference — flag in QA if a softer shade is wanted (\`--dv-color-sage\` and \`--dv-color-sage-soft\` are both available; currently using \`--dv-color-sage-deep\`).

## Out of scope

- Tagline copy ("Momenti italiani per te e il tuo piccolino") — separate decision in pre-launch polish.
- Sub-brand lockup variants (Cucina, classes) — out of scope until those chapters are commissioned (ADR 0002).
- Issue #27 ("mama e bambino" script treatment in hero subhead) — separate pre-launch polish task.

Made with [Cursor](https://cursor.com)