### PR TITLE
feat(m6a): wire Vercel Web Analytics + Speed Insights (#21)

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,8 @@
 	},
 	"dependencies": {
 		"@directus/sdk": "^20.2.0",
+		"@vercel/analytics": "^2.0.1",
+		"@vercel/speed-insights": "^2.0.0",
 		"resend": "^4.0.0",
 		"zod": "^3.24.0"
 	},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,12 @@ importers:
       '@directus/sdk':
         specifier: ^20.2.0
         version: 20.3.0
+      '@vercel/analytics':
+        specifier: ^2.0.1
+        version: 2.0.1(@sveltejs/kit@2.57.1(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.55.4(@typescript-eslint/types@8.59.0))(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)))(svelte@5.55.4(@typescript-eslint/types@8.59.0))(typescript@5.9.3)(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)))(react@19.2.5)(svelte@5.55.4(@typescript-eslint/types@8.59.0))
+      '@vercel/speed-insights':
+        specifier: ^2.0.0
+        version: 2.0.0(@sveltejs/kit@2.57.1(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.55.4(@typescript-eslint/types@8.59.0))(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)))(svelte@5.55.4(@typescript-eslint/types@8.59.0))(typescript@5.9.3)(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)))(react@19.2.5)(svelte@5.55.4(@typescript-eslint/types@8.59.0))
       resend:
         specifier: ^4.0.0
         version: 4.8.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -891,10 +897,65 @@ packages:
     resolution: {integrity: sha512-/uejZt4dSere1bx12WLlPfv8GktzcaDtuJ7s42/HEZ5zGj9oxRaD4bj7qwSunXkf+pbAhFt2zjpHYUiT5lHf0Q==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@vercel/analytics@2.0.1':
+    resolution: {integrity: sha512-MTQG6V9qQrt1tsDeF+2Uoo5aPjqbVPys1xvnIftXSJYG2SrwXRHnqEvVoYID7BTruDz4lCd2Z7rM1BdkUehk2g==}
+    peerDependencies:
+      '@remix-run/react': ^2
+      '@sveltejs/kit': ^1 || ^2
+      next: '>= 13'
+      nuxt: '>= 3'
+      react: ^18 || ^19 || ^19.0.0-rc
+      svelte: '>= 4'
+      vue: ^3
+      vue-router: ^4
+    peerDependenciesMeta:
+      '@remix-run/react':
+        optional: true
+      '@sveltejs/kit':
+        optional: true
+      next:
+        optional: true
+      nuxt:
+        optional: true
+      react:
+        optional: true
+      svelte:
+        optional: true
+      vue:
+        optional: true
+      vue-router:
+        optional: true
+
   '@vercel/nft@1.5.0':
     resolution: {integrity: sha512-IWTDeIoWhQ7ZtRO/JRKH+jhmeQvZYhtGPmzw/QGDY+wDCQqfm25P9yIdoAFagu4fWsK4IwZXDFIjrmp5rRm/sA==}
     engines: {node: '>=20'}
     hasBin: true
+
+  '@vercel/speed-insights@2.0.0':
+    resolution: {integrity: sha512-jwkNcrTeafWxjmWq4AHBaptSqZiJkYU5adLC9QBSqeim0GcqDMgN5Ievh8OG1rJ6W3A4l1oiP7qr9CWxGuzu3w==}
+    peerDependencies:
+      '@sveltejs/kit': ^1 || ^2
+      next: '>= 13'
+      nuxt: '>= 3'
+      react: ^18 || ^19 || ^19.0.0-rc
+      svelte: '>= 4'
+      vue: ^3
+      vue-router: ^4
+    peerDependenciesMeta:
+      '@sveltejs/kit':
+        optional: true
+      next:
+        optional: true
+      nuxt:
+        optional: true
+      react:
+        optional: true
+      svelte:
+        optional: true
+      vue:
+        optional: true
+      vue-router:
+        optional: true
 
   '@vitest/expect@4.1.4':
     resolution: {integrity: sha512-iPBpra+VDuXmBFI3FMKHSFXp3Gx5HfmSCE8X67Dn+bwephCnQCaB7qWK2ldHa+8ncN8hJU8VTMcxjPpyMkUjww==}
@@ -2551,6 +2612,12 @@ snapshots:
       '@typescript-eslint/types': 8.59.0
       eslint-visitor-keys: 5.0.1
 
+  '@vercel/analytics@2.0.1(@sveltejs/kit@2.57.1(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.55.4(@typescript-eslint/types@8.59.0))(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)))(svelte@5.55.4(@typescript-eslint/types@8.59.0))(typescript@5.9.3)(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)))(react@19.2.5)(svelte@5.55.4(@typescript-eslint/types@8.59.0))':
+    optionalDependencies:
+      '@sveltejs/kit': 2.57.1(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.55.4(@typescript-eslint/types@8.59.0))(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)))(svelte@5.55.4(@typescript-eslint/types@8.59.0))(typescript@5.9.3)(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0))
+      react: 19.2.5
+      svelte: 5.55.4(@typescript-eslint/types@8.59.0)
+
   '@vercel/nft@1.5.0(rollup@4.60.2)':
     dependencies:
       '@mapbox/node-pre-gyp': 2.0.3
@@ -2569,6 +2636,12 @@ snapshots:
       - encoding
       - rollup
       - supports-color
+
+  '@vercel/speed-insights@2.0.0(@sveltejs/kit@2.57.1(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.55.4(@typescript-eslint/types@8.59.0))(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)))(svelte@5.55.4(@typescript-eslint/types@8.59.0))(typescript@5.9.3)(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)))(react@19.2.5)(svelte@5.55.4(@typescript-eslint/types@8.59.0))':
+    optionalDependencies:
+      '@sveltejs/kit': 2.57.1(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.55.4(@typescript-eslint/types@8.59.0))(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)))(svelte@5.55.4(@typescript-eslint/types@8.59.0))(typescript@5.9.3)(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0))
+      react: 19.2.5
+      svelte: 5.55.4(@typescript-eslint/types@8.59.0)
 
   '@vitest/expect@4.1.4':
     dependencies:

--- a/spec.md
+++ b/spec.md
@@ -4,7 +4,7 @@
 > **Domain:** https://dolcevitact.com (the `ct` suffix is a domain-availability quirk — the brand is "Dolce Vita")
 > **First chapter:** Dolce Vita Baby Circle
 > **Brand architecture:** branded house, paths-first (see [`.docs/adrs/0002-brand-architecture.md`](./.docs/adrs/0002-brand-architecture.md))
-> **Status:** M5 RSVP intake in review (PR #28). M2 Directus schema complete + verified Apr 21 2026 ([`.docs/operations/m2-verification.md`](./.docs/operations/m2-verification.md)). M4 (sections) split into M4a/b/c — all merged. M6 (Launch) is the next active milestone.
+> **Status:** M0–M5 complete. Brand rename + ADR 0002 merged (PR #30). Canonical brand lockup component shipped (PR #33, closes #32). **M6 Launch in progress** — split into M6a (analytics) → M6b (SEO) → M6c (a11y/perf) → M6d (security headers) → M6e (release cut).
 > **Last Updated:** April 25, 2026
 
 This is the single source of truth for what `dolcevitact-web` is, why it exists,
@@ -64,35 +64,37 @@ configuration. Repo-local rules live in `.cursor/rules/` (when added).
 
 ## 4. Sections
 
-The homepage is a single Directus `pages` row composed of M2A blocks:
+The homepage is a single Directus `pages` row composed of M2A blocks. All
+section blocks shipped through M4a/b/c. The brand mark above the hero ships
+via the canonical `BrandLockup` component (M6, PR #33).
 
-| Section                  | Block                                 | Status             |
-| ------------------------ | ------------------------------------- | ------------------ |
-| Hero                     | `block_hero`                          | pending (M2/M4)    |
-| About the experience     | `block_card_group`                    | pending            |
-| How it works             | `block_timeline`                      | pending            |
-| Who it's for             | `block_card_group`                    | pending            |
-| Founder                  | `block_team` (single member)          | pending            |
-| Event details            | `block_event_details` (NEW)           | pending (M1/M2)    |
-| RSVP                     | `block_rsvp_form` (NEW)               | pending (M1/M2/M5) |
-| Brand story / philosophy | `block_rich_text`                     | pending            |
-| FAQ                      | `block_faq` + `block_faq_items` (NEW) | pending (M1/M2)    |
-| Footer                   | layout component                      | pending            |
+| Section                  | Block                               | Status                  |
+| ------------------------ | ----------------------------------- | ----------------------- |
+| Hero                     | `block_hero` + `BrandLockup`        | done (M4a/c, M6 lockup) |
+| About the experience     | `block_card_group`                  | done (M4a/c)            |
+| How it works             | `block_timeline`                    | done (M4a/c)            |
+| Who it's for             | `block_card_group`                  | done (M4a/c)            |
+| Founder                  | `block_team` (single member)        | done (M4a/c)            |
+| Event details            | `block_event_details`               | done (M1/M2/M4)         |
+| RSVP                     | `block_rsvp_form` + `?/rsvp` action | done (M1/M2/M5)         |
+| Brand story / philosophy | `block_rich_text`                   | done (M4a/c)            |
+| FAQ                      | `block_faq` + `block_faq_items`     | done (M1/M2/M4)         |
+| Sticky nav + footer      | `SiteNav` + `SiteFooter`            | done (M4b)              |
 
 ---
 
 ## 5. Milestones
 
-| ID  | Name                     | Status      | GitHub Milestone                                                   | Notes                                                                                                                                                                                                           |
-| --- | ------------------------ | ----------- | ------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| M-1 | GitHub workspace         | done        | —                                                                  | Repo, labels, templates, board, epics, stories                                                                                                                                                                  |
-| M0  | Foundation               | in progress | [#1](https://github.com/BravoByte-org/dolcevitact-web/milestone/1) | Scaffold + Directus site row + Vercel + DNS                                                                                                                                                                     |
-| M1  | Shared content contracts | in review   | [#2](https://github.com/BravoByte-org/dolcevitact-web/milestone/2) | `@bravobyte/types` extension (types PR #2)                                                                                                                                                                      |
-| M2  | Directus schema          | done        | [#3](https://github.com/BravoByte-org/dolcevitact-web/milestone/3) | Idempotent migration applied + verified Apr 21 2026 (runlog: [`.docs/operations/m2-verification.md`](./.docs/operations/m2-verification.md))                                                                    |
-| M3  | Design system            | done        | [#4](https://github.com/BravoByte-org/dolcevitact-web/milestone/4) | Tokens, decoratives, motion (PR #16 merged)                                                                                                                                                                     |
-| M4  | Sections                 | in progress | [#5](https://github.com/BravoByte-org/dolcevitact-web/milestone/5) | M4a block shell + M4b nav merged. M4a-polish: rule-compliant `@apply` refactor + a11y smoke — styling guide: [`.docs/architecture/block-styling-guide.md`](./.docs/architecture/block-styling-guide.md)         |
-| M5  | RSVP                     | in progress | [#6](https://github.com/BravoByte-org/dolcevitact-web/milestone/6) | `?/rsvp` form action → Zod validate → Directus `rsvp_submissions` write → Resend notification + honeypot + success/error UI. Plan: [`.docs/architecture/m5-rsvp-plan.md`](./.docs/architecture/m5-rsvp-plan.md) |
-| M6  | Launch                   | planned     | [#7](https://github.com/BravoByte-org/dolcevitact-web/milestone/7) | SEO, a11y, deploy                                                                                                                                                                                               |
+| ID  | Name                     | Status      | GitHub Milestone                                                   | Notes                                                                                                                                                                                                                                                                                            |
+| --- | ------------------------ | ----------- | ------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| M-1 | GitHub workspace         | done        | —                                                                  | Repo, labels, templates, board, epics, stories                                                                                                                                                                                                                                                   |
+| M0  | Foundation               | done        | [#1](https://github.com/BravoByte-org/dolcevitact-web/milestone/1) | Scaffold + Directus `dolcevita` site row + Vercel + DNS (DNS verified by founder)                                                                                                                                                                                                                |
+| M1  | Shared content contracts | done        | [#2](https://github.com/BravoByte-org/dolcevitact-web/milestone/2) | `@bravobyte/types` extension shipped + consumed                                                                                                                                                                                                                                                  |
+| M2  | Directus schema          | done        | [#3](https://github.com/BravoByte-org/dolcevitact-web/milestone/3) | Idempotent migration applied + verified Apr 21 2026 (runlog: [`.docs/operations/m2-verification.md`](./.docs/operations/m2-verification.md))                                                                                                                                                     |
+| M3  | Design system            | done        | [#4](https://github.com/BravoByte-org/dolcevitact-web/milestone/4) | Tokens, decoratives, motion (PR #16)                                                                                                                                                                                                                                                             |
+| M4  | Sections                 | done        | [#5](https://github.com/BravoByte-org/dolcevitact-web/milestone/5) | M4a block shell (PR #20), M4b sticky nav + drawer (PR #23), M4c full styling + a11y smoke (PR #26). Styling guide: [`.docs/architecture/block-styling-guide.md`](./.docs/architecture/block-styling-guide.md)                                                                                    |
+| M5  | RSVP                     | done        | [#6](https://github.com/BravoByte-org/dolcevitact-web/milestone/6) | `?/rsvp` form action → Zod validate → Directus `rsvp_submissions` write → Resend notification + honeypot + success/error UI (PR #28). Brand rename promoted via PR #30 (recovery from stranded stack). Plan: [`.docs/architecture/m5-rsvp-plan.md`](./.docs/architecture/m5-rsvp-plan.md)        |
+| M6  | Launch                   | in progress | [#7](https://github.com/BravoByte-org/dolcevitact-web/milestone/7) | Brand lockup component done (PR #33). Remaining: M6a Vercel Analytics + Speed Insights (#21) → M6b SEO/OG/JSON-LD/sitemap (#12 part 1) → M6c a11y + perf + Lighthouse ≥95 (#12 part 2) → M6d `vercel.json` security headers (#13 part 1) → M6e release cut + DNS verify + RSVP smoke (#13 + #24) |
 
 GitHub Project board: [BravoByte/Dolce Vita Board](https://github.com/orgs/BravoByte-org/projects/4)
 

--- a/src/routes/(app)/+layout.svelte
+++ b/src/routes/(app)/+layout.svelte
@@ -1,11 +1,28 @@
 <script lang="ts">
 	import '../../app.css';
+	import { dev } from '$app/environment';
+	import { injectAnalytics } from '@vercel/analytics/sveltekit';
+	import { injectSpeedInsights } from '@vercel/speed-insights/sveltekit';
 	import Grain from '$components/decor/Grain.svelte';
 	import SiteNav from '$components/navigation/SiteNav.svelte';
 	import SiteFooter from '$components/navigation/SiteFooter.svelte';
 	import type { NavItem } from '$components/navigation/types';
 	import type { LayoutData } from './$types';
 	import type { Snippet } from 'svelte';
+
+	/*
+	 * Vercel Web Analytics + Speed Insights are wired here at the (app)
+	 * layout level so every marketing route is tracked from a single
+	 * place. Both helpers are SSR-safe — they no-op on the server and
+	 * inject their scripts on the client. No env vars or tokens are
+	 * required: Vercel auto-detects the deployment ID at runtime.
+	 *
+	 * `mode: dev ? 'development' : 'production'` keeps local `pnpm dev`
+	 * out of the prod analytics bucket while still letting us verify the
+	 * `/_vercel/insights/*` requests fire end-to-end on preview deploys.
+	 */
+	injectAnalytics({ mode: dev ? 'development' : 'production' });
+	injectSpeedInsights();
 
 	let { data, children }: { data: LayoutData; children: Snippet } = $props();
 


### PR DESCRIPTION
## Summary

Wires Vercel Web Analytics and Speed Insights into `src/routes/(app)/+layout.svelte` (the marketing-route shell), so traffic + Core Web Vitals start collecting on the next preview deploy. Closes part of #21 — verification is the second half.

Also refreshes `spec.md` so the milestone status table reflects today's reality (M0–M5 all done, M4 closed via M4a/b/c, M6 split into M6a–M6e with M6a being this PR).

## What changed

- **`package.json`** — adds `@vercel/analytics ^2.0.1` and `@vercel/speed-insights ^2.0.0` as production dependencies.
- **`src/routes/(app)/+layout.svelte`** — calls `injectAnalytics({ mode: dev ? 'development' : 'production' })` and `injectSpeedInsights()` at module scope. Both helpers SSR-no-op and inject their scripts on the client. No env vars / tokens needed (Vercel auto-detects deployment ID).
- **`spec.md`** — milestone table refresh + Section 4 (Sections) status update + new top-of-file status line covering M6a–M6e.

## Why split M6 into a/b/c/d/e

M6 contains 5 distinct concerns (analytics, SEO, a11y/perf, security headers, release cut). Per your standing instruction to keep frontend changes flowing through focused PRs to `next` for QA preview deploys, each ships as its own PR rather than one giant launch PR. M6a goes first because it gives every downstream PR a baseline of analytics + Web Vitals data to evaluate against.

## Test plan

- [x] Local: `pnpm format` / `pnpm lint` / `pnpm check` (0 errors, 0 warnings) / `pnpm test` (7/7) / `pnpm build` — all green.
- [x] CI: bravobyte-platform reusable workflow.
- [x] Vercel preview deploy:
  - [x] DevTools → Network shows two scripts loaded (under randomized hash paths like `/<hash>/script.js` — Vercel obfuscates the path to evade adblockers; the scripts internally POST to `_vercel/insights` and `_vercel/speed-insights`). Inline content of both scripts confirmed: one defines `window.va` + `_vercel/insights` endpoints (analytics), the other defines `window.si` + `_vercel/speed-insights/vitals` endpoints (speed insights).
  - [x] No console errors / CSP violations (CSP gets locked down in M6d — current state is permissive).
- [ ] Post-merge → production:
  - [ ] Filter Network for `view` (analytics POST) and `vitals` (speed insights POST) — confirm 202s on navigation / pagehide.
  - [ ] Vercel project → Analytics dashboard flips from "0 online" → live page-view count after one prod navigation (~1 min lag).
  - [ ] Vercel project → Speed Insights starts populating CWV scores within a few minutes of real traffic.

> **Note on Vercel script paths:** The official docs in #21 reference `/_vercel/insights/script.js` and `/_vercel/speed-insights/script.js`, but newer SDK versions (`@vercel/analytics ^2.0`, `@vercel/speed-insights ^2.0`) serve the scripts under randomized hash paths (e.g. `/990e1a0bb3ac424a/script.js`) as anti-adblock obfuscation. The internal POST endpoints `/_vercel/insights/view` and `/_vercel/speed-insights/vitals` are the canonical proof that data is flowing.

## Out of scope

- OG image / favicon / JSON-LD → M6b.
- Lighthouse ≥95 audit → M6c.
- CSP / HSTS / security headers → M6d.
- Production promote + DNS verify + RSVP smoke → M6e.