### PR TITLE
feat(m6b): SEO foundations — per-page meta + OG/Twitter + LocalBusiness JSON-LD + sitemap + favicon (#12 part 1)

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -4,7 +4,7 @@
 > **Domain:** https://dolcevitact.com (the `ct` suffix is a domain-availability quirk — the brand is "Dolce Vita")
 > **First chapter:** Dolce Vita Baby Circle
 > **Brand architecture:** branded house, paths-first (see [`.docs/adrs/0002-brand-architecture.md`](./.docs/adrs/0002-brand-architecture.md))
-> **Status:** M0–M5 complete. Brand rename + ADR 0002 merged (PR #30). Canonical brand lockup component shipped (PR #33, closes #32). **M6 Launch in progress** — split into M6a (analytics) → M6b (SEO) → M6c (a11y/perf) → M6d (security headers) → M6e (release cut).
+> **Status:** M0–M5 complete. Brand rename + ADR 0002 merged (PR #30). Canonical brand lockup component shipped (PR #33, closes #32). **M6 Launch in progress** — M6a analytics shipped (PR #34); M6b SEO foundations in flight; remaining: M6c (a11y/perf) → M6d (security headers) → M6e (release cut).
 > **Last Updated:** April 25, 2026
 
 This is the single source of truth for what `dolcevitact-web` is, why it exists,
@@ -94,7 +94,7 @@ via the canonical `BrandLockup` component (M6, PR #33).
 | M3  | Design system            | done        | [#4](https://github.com/BravoByte-org/dolcevitact-web/milestone/4) | Tokens, decoratives, motion (PR #16)                                                                                                                                                                                                                                                             |
 | M4  | Sections                 | done        | [#5](https://github.com/BravoByte-org/dolcevitact-web/milestone/5) | M4a block shell (PR #20), M4b sticky nav + drawer (PR #23), M4c full styling + a11y smoke (PR #26). Styling guide: [`.docs/architecture/block-styling-guide.md`](./.docs/architecture/block-styling-guide.md)                                                                                    |
 | M5  | RSVP                     | done        | [#6](https://github.com/BravoByte-org/dolcevitact-web/milestone/6) | `?/rsvp` form action → Zod validate → Directus `rsvp_submissions` write → Resend notification + honeypot + success/error UI (PR #28). Brand rename promoted via PR #30 (recovery from stranded stack). Plan: [`.docs/architecture/m5-rsvp-plan.md`](./.docs/architecture/m5-rsvp-plan.md)        |
-| M6  | Launch                   | in progress | [#7](https://github.com/BravoByte-org/dolcevitact-web/milestone/7) | Brand lockup component done (PR #33). Remaining: M6a Vercel Analytics + Speed Insights (#21) → M6b SEO/OG/JSON-LD/sitemap (#12 part 1) → M6c a11y + perf + Lighthouse ≥95 (#12 part 2) → M6d `vercel.json` security headers (#13 part 1) → M6e release cut + DNS verify + RSVP smoke (#13 + #24) |
+| M6  | Launch                   | in progress | [#7](https://github.com/BravoByte-org/dolcevitact-web/milestone/7) | Brand lockup (PR #33) + M6a analytics (PR #34) done. M6b SEO foundations in flight: per-page meta, OG/Twitter cards, `LocalBusiness` JSON-LD, `/sitemap.xml`, favicon SVG + manifest (#12 part 1). Remaining: M6c a11y + perf + Lighthouse ≥95 (#12 part 2) → M6d `vercel.json` security headers (#13 part 1) → M6e release cut + DNS verify + RSVP smoke (#13 + #24) |
 
 GitHub Project board: [BravoByte/Dolce Vita Board](https://github.com/orgs/BravoByte-org/projects/4)
 

--- a/src/app.html
+++ b/src/app.html
@@ -3,8 +3,12 @@
 	<head>
 		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
-		<meta name="theme-color" content="#F6F1EC" />
-		<link rel="icon" href="%sveltekit.assets%/favicon.ico" />
+		<!--
+			SEO / favicon / theme-color / manifest / OG / Twitter / JSON-LD all
+			live in the (app) layout + page heads — not here. Keeping app.html
+			minimal means we don't ship duplicated meta tags or stale fallbacks
+			(e.g. a broken /favicon.ico) once a route head loads.
+		-->
 		%sveltekit.head%
 	</head>
 	<body data-sveltekit-preload-data="hover" class="bg-ivory text-charcoal antialiased">

--- a/src/routes/(app)/+layout.svelte
+++ b/src/routes/(app)/+layout.svelte
@@ -34,21 +34,25 @@
 </script>
 
 <svelte:head>
-	<title>{siteTitle} — Italian-inspired mama & bambino circle in Stamford, CT</title>
-	<meta
-		name="description"
-		content={site?.description ??
-			'Dolce Vita Baby Circle — an Italian-inspired morning of music, language, and movement for mama and bambino in Stamford, Connecticut. The first chapter of Dolce Vita.'}
-	/>
-	<link rel="canonical" href="https://dolcevitact.com/" />
-	<meta property="og:type" content="website" />
-	<meta property="og:title" content={siteTitle} />
-	<meta
-		property="og:description"
-		content="A warm, refined Italian-inspired class for moms and babies in Stamford, CT."
-	/>
-	<meta property="og:url" content="https://dolcevitact.com/" />
+	<!--
+		Site-wide head: only tags that DON'T vary per-page live here. Per-page
+		title / description / canonical / og:url / og:image / twitter / JSON-LD
+		are owned by each `+page.svelte` so the route can override cleanly
+		without duplicate `<title>` tags.
+	-->
+
+	<meta name="theme-color" content="#f6f1ec" />
+	<meta name="apple-mobile-web-app-title" content="Dolce Vita" />
+	<meta name="application-name" content="Dolce Vita Baby Circle" />
+	<meta name="format-detection" content="telephone=no" />
+
+	<meta property="og:site_name" content="Dolce Vita Baby Circle" />
 	<meta property="og:locale" content="en_US" />
+	<meta name="twitter:card" content="summary_large_image" />
+
+	<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+	<link rel="manifest" href="/site.webmanifest" />
+
 	<link rel="preconnect" href="https://fonts.googleapis.com" />
 	<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="anonymous" />
 	<link

--- a/src/routes/(app)/+page.svelte
+++ b/src/routes/(app)/+page.svelte
@@ -8,24 +8,123 @@
 
 	let { data }: { data: PageData } = $props();
 
+	/*
+	 * Site-wide constants used by per-page SEO + structured data. Hard-coded
+	 * here (vs. pulled from CMS) because they're identity-level: the
+	 * canonical URL, brand name, and OG image asset don't vary by page or
+	 * by Directus content. If/when sibling chapters launch (e.g. /cucina),
+	 * each `+page.svelte` will own its own canonical URL + page-specific
+	 * SEO block.
+	 */
+	const SITE_URL = 'https://dolcevitact.com';
+	const SITE_BRAND = 'Dolce Vita Baby Circle';
+	const PAGE_URL = `${SITE_URL}/`;
+
+	/*
+	 * OG image — placeholder URL via placehold.co with brand-aligned hex
+	 * colors so rich previews render today (Slack, Discord, Twitter, FB,
+	 * LinkedIn, iMessage). Pre-launch polish replaces this with a designer
+	 * asset hosted at `/og-image.png` (see follow-up issue).
+	 */
+	const OG_IMAGE = 'https://placehold.co/1200x630/f6f1ec/b8694b/png?text=Dolce+Vita+Baby+Circle';
+
 	const page = $derived((data.pages?.[0] as Record<string, unknown> | undefined) ?? null);
 	const blocks = $derived(
 		(page?.blocks as Block[] | undefined)?.filter((b) => b && b.collection && b.item) ?? []
 	);
-	const seoTitle = $derived(
-		(page?.seo_title as string | undefined) ??
-			(page?.title as string | undefined) ??
-			'Dolce Vita Baby Circle'
-	);
-	const seoDescription = $derived(
+	const cmsSeoTitle = $derived(page?.seo_title as string | undefined);
+	const pageTitle = $derived(cmsSeoTitle ?? (page?.title as string | undefined) ?? SITE_BRAND);
+	const pageDescription = $derived(
 		(page?.seo_description as string | undefined) ??
 			'An Italian-inspired morning for mama and bambino in Stamford, CT — the first chapter of Dolce Vita.'
+	);
+
+	/*
+	 * Title-construction policy:
+	 *   - When the CMS has an `seo_title`, treat it as editor-authored and
+	 *     use it verbatim. Editors can include the brand themselves (and
+	 *     usually do) — appending it would produce things like
+	 *     "Dolce Vita Baby Circle — ... | Dolce Vita Baby Circle".
+	 *   - Otherwise, use either the page's plain `title` suffixed with the
+	 *     brand, or just the brand alone.
+	 */
+	const fullTitle = $derived.by(() => {
+		if (cmsSeoTitle) return cmsSeoTitle;
+		if (pageTitle === SITE_BRAND) return SITE_BRAND;
+		return `${pageTitle} | ${SITE_BRAND}`;
+	});
+
+	/*
+	 * Schema.org LocalBusiness block — drives rich-result eligibility for
+	 * "Dolce Vita Baby Circle" knowledge-panel surfaces in Google. Kept as
+	 * a derived JSON object then stringified at render time so future
+	 * page-specific entries (e.g. Event for the next class date) compose
+	 * cleanly. Skipping `Event` for now: until founder confirms session
+	 * dates, posting fake dates would risk a "deceptive structured data"
+	 * penalty.
+	 */
+	const localBusinessJsonLd = $derived(
+		JSON.stringify({
+			'@context': 'https://schema.org',
+			'@type': 'LocalBusiness',
+			'@id': `${SITE_URL}/#localbusiness`,
+			name: SITE_BRAND,
+			alternateName: 'Dolce Vita',
+			description: pageDescription,
+			url: PAGE_URL,
+			image: OG_IMAGE,
+			email: 'babycircle@dolcevitact.com',
+			address: {
+				'@type': 'PostalAddress',
+				addressLocality: 'Stamford',
+				addressRegion: 'CT',
+				addressCountry: 'US'
+			},
+			areaServed: {
+				'@type': 'City',
+				name: 'Stamford'
+			}
+		})
+			// Defensive escapes: CMS-supplied text could include `<`, `>`, or
+			// `&` which would otherwise let an editor's content escape the
+			// `<script type="application/ld+json">` block. JSON.stringify alone
+			// does NOT escape these (only quotes / control chars).
+			.replace(/</g, '\\u003c')
+			.replace(/>/g, '\\u003e')
+			.replace(/&/g, '\\u0026')
 	);
 </script>
 
 <svelte:head>
-	<title>{seoTitle} | Dolce Vita Baby Circle</title>
-	<meta name="description" content={seoDescription} />
+	<title>{fullTitle}</title>
+	<meta name="description" content={pageDescription} />
+	<link rel="canonical" href={PAGE_URL} />
+
+	<meta property="og:type" content="website" />
+	<meta property="og:url" content={PAGE_URL} />
+	<meta property="og:title" content={fullTitle} />
+	<meta property="og:description" content={pageDescription} />
+	<meta property="og:image" content={OG_IMAGE} />
+	<meta property="og:image:width" content="1200" />
+	<meta property="og:image:height" content="630" />
+	<meta
+		property="og:image:alt"
+		content="{SITE_BRAND} — Italian-inspired morning for mama and bambino"
+	/>
+
+	<meta name="twitter:title" content={fullTitle} />
+	<meta name="twitter:description" content={pageDescription} />
+	<meta name="twitter:image" content={OG_IMAGE} />
+
+	<!--
+		Standard SvelteKit JSON-LD pattern. The JSON above is .replace()-d to
+		escape `<`, `>`, and `&` as unicode escapes, so editor-supplied CMS
+		text cannot break out of the script tag. The closing `</script>` is
+		split across a string concatenation so Svelte's template compiler
+		doesn't terminate the route's `<svelte:head>` block prematurely.
+	-->
+	<!-- eslint-disable-next-line svelte/no-at-html-tags -->
+	{@html `<script type="application/ld+json">${localBusinessJsonLd}</` + `script>`}
 </svelte:head>
 
 {#if blocks.length > 0}

--- a/src/routes/sitemap.xml/+server.ts
+++ b/src/routes/sitemap.xml/+server.ts
@@ -1,0 +1,60 @@
+import type { RequestHandler } from './$types';
+
+/*
+ * Sitemap — single canonical URL today (`/`). Section anchors (`#about`,
+ * `#rsvp`, etc.) are NOT separate URLs in Google's view, so they don't
+ * belong here. When sibling chapters land (`/cucina`, `/classes`, ...)
+ * each gets its own `<url>` block per ADR 0002 (paths-first architecture).
+ *
+ * The URL is hard-coded to the canonical production hostname to match
+ * `<link rel="canonical">` and avoid leaking preview-deploy hosts into
+ * search-engine indexing.
+ */
+
+const SITE_URL = 'https://dolcevitact.com';
+
+type SitemapEntry = {
+	loc: string;
+	lastmod?: string;
+	changefreq?: 'always' | 'hourly' | 'daily' | 'weekly' | 'monthly' | 'yearly' | 'never';
+	priority?: string;
+};
+
+const entries: SitemapEntry[] = [
+	{
+		loc: `${SITE_URL}/`,
+		changefreq: 'monthly',
+		priority: '1.0'
+	}
+];
+
+function renderSitemap(items: SitemapEntry[]): string {
+	const urls = items
+		.map((entry) => {
+			const parts = [`    <loc>${entry.loc}</loc>`];
+			if (entry.lastmod) parts.push(`    <lastmod>${entry.lastmod}</lastmod>`);
+			if (entry.changefreq) parts.push(`    <changefreq>${entry.changefreq}</changefreq>`);
+			if (entry.priority) parts.push(`    <priority>${entry.priority}</priority>`);
+			return `  <url>\n${parts.join('\n')}\n  </url>`;
+		})
+		.join('\n');
+
+	return `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+${urls}
+</urlset>
+`;
+}
+
+export const GET: RequestHandler = () =>
+	new Response(renderSitemap(entries), {
+		headers: {
+			'Content-Type': 'application/xml; charset=utf-8',
+			// Sitemap is static today; revalidate cheaply at the edge once an
+			// hour so future content additions land within the SLA Google
+			// fetches at, without paying SSR cost on every crawl.
+			'Cache-Control': 'public, max-age=0, s-maxage=3600, stale-while-revalidate=86400'
+		}
+	});
+
+export const prerender = true;

--- a/static/favicon.svg
+++ b/static/favicon.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="Dolce Vita Baby Circle">
+  <title>Dolce Vita Baby Circle</title>
+  <rect width="64" height="64" rx="12" fill="#F6F1EC"/>
+  <path
+    fill="#B8694B"
+    d="M32 50s-15-9.3-19.5-19.5C9.4 22.7 13.7 16 21 16c4.3 0 7.4 2.2 11 6.5C35.6 18.2 38.7 16 43 16c7.3 0 11.6 6.7 8.5 14.5C47 40.7 32 50 32 50z"
+  />
+</svg>

--- a/static/site.webmanifest
+++ b/static/site.webmanifest
@@ -1,0 +1,19 @@
+{
+  "name": "Dolce Vita Baby Circle",
+  "short_name": "Dolce Vita",
+  "description": "An Italian-inspired morning of music, language, and movement for mama and bambino in Stamford, Connecticut.",
+  "start_url": "/",
+  "scope": "/",
+  "display": "browser",
+  "theme_color": "#f6f1ec",
+  "background_color": "#f6f1ec",
+  "lang": "en-US",
+  "icons": [
+    {
+      "src": "/favicon.svg",
+      "type": "image/svg+xml",
+      "sizes": "any",
+      "purpose": "any"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

M6b ships the SEO foundations for `dolcevitact.com`. Closes part 1 of #12 (the SEO/OG/JSON-LD/sitemap slice). Lighthouse + a11y pass lands in the sibling M6c PR.

### Head architecture (single source of truth)

| Tag(s) | Owner |
|---|---|
| `og:site_name`, `og:locale`, `theme-color`, favicon SVG, web manifest, font preload, `twitter:card` | `(app)/+layout.svelte` |
| `<title>`, `description`, canonical, `og:title/desc/url/image`, `twitter:title/desc/image`, `LocalBusiness` JSON-LD | `(app)/+page.svelte` |

This eliminates duplicate `<title>` emissions and stale fallbacks. Verified single `<title>` + single `theme-color` + single `<link rel=\"icon\">` in rendered HTML.

### What's in

- `LocalBusiness` schema.org JSON-LD inline (name, alternateName, description, url, image, email, address, areaServed). Defensively unicode-escapes `<`/`>`/`&` so editor CMS text can't break out of the script tag.
- Prerendered `/sitemap.xml` (single canonical entry for `/`; section anchors aren't separate URLs in Google's view). Robots.txt already references this URL.
- `static/favicon.svg` — terracotta heart on ivory matching the brand lockup.
- `static/site.webmanifest` — minimal PWA manifest with brand colors.
- Smarter title: when CMS supplies an editor-authored `seo_title`, render verbatim (editors usually include the brand themselves). Otherwise fall back to `{page.title} | Dolce Vita Baby Circle` or brand alone.
- `app.html` cleanup: removed duplicate `theme-color` and the broken `/favicon.ico` reference.
- `spec.md`: marks M6a complete, M6b in flight, lists remaining M6c/d/e.

### What's deferred (follow-up issue, pre-launch polish)

- **OG image asset** — meta tags currently point to a `placehold.co` URL with brand-aligned hex (`#f6f1ec` bg, `#b8694b` text). Rich previews work today; designer-produced `og-image.png` swaps in pre-launch.
- **`Event` JSON-LD** — needs founder-confirmed session dates. Posting placeholder dates risks Google's \"deceptive structured data\" penalty.
- **Raster favicon fallbacks** — `favicon.ico`, `apple-touch-icon.png` (SVG covers 99% of modern browsers).

## Test plan

- [x] Local: `pnpm format` / `pnpm lint` (0/0) / `pnpm check` (0/0) / `pnpm test` (7/7) / `pnpm build` — all green.
- [x] Preview smoke (`pnpm preview`):
  - [x] `curl /` → exactly one `<title>`, one `theme-color`, one `rel=\"icon\"` (no dupes from `app.html`).
  - [x] `<title>` reads `Dolce Vita Baby Circle — Italian-inspired mama & bambino in Stamford, CT` (no `| Dolce Vita Baby Circle` repeat).
  - [x] All `og:*` + `twitter:*` tags present with correct content.
  - [x] `<script type=\"application/ld+json\">` parses to a valid `LocalBusiness` block.
  - [x] `curl /sitemap.xml` → valid XML, references `https://dolcevitact.com/`, `Content-Type: application/xml`.
  - [x] `curl /favicon.svg` → 200, 389 bytes.
  - [x] `curl /site.webmanifest` → 200, valid JSON.
  - [x] `curl /robots.txt` → unchanged, references sitemap.
- [ ] CI: bravobyte-platform reusable workflow.
- [ ] Vercel preview deploy:
  - [ ] View page source — confirm head structure matches local preview.
  - [ ] [Google Rich Results Test](https://search.google.com/test/rich-results) on the preview URL → `LocalBusiness` detected, no errors.
  - [ ] [Facebook Sharing Debugger](https://developers.facebook.com/tools/debug/) → preview card renders with placeholder OG image.
  - [ ] DevTools → Application → Manifest tab → name/colors/icon load cleanly.

## Follow-up issue (will file after merge)

- OG image asset (designer-produced 1200×630 PNG)
- Raster favicon fallbacks (`favicon.ico`, `apple-touch-icon.png`)
- `Event` JSON-LD (gated on founder-confirmed dates)


Made with [Cursor](https://cursor.com)