### PR TITLE
chore(theme): wire bravobyte frontend-core token contract

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,5 @@
+# BravoByte private packages — published to GitHub Packages.
+# Auth token is supplied locally / in CI via NODE_AUTH_TOKEN or .env.
+# See https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-npm-registry
+@bravobyte-org:registry=https://npm.pkg.github.com
+//npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}

--- a/spec.md
+++ b/spec.md
@@ -50,12 +50,12 @@ configuration. Repo-local rules live in `.cursor/rules/` (when added).
 
 ## 3. Repo placement (Rule Zero)
 
-| Concern                                                     | Repo                                                                      | Why                        |
-| ----------------------------------------------------------- | ------------------------------------------------------------------------- | -------------------------- |
-| Brand copy, palette, typography, imagery, page composition  | this repo                                                                 | client-local               |
+| Concern                                                     | Repo                                                                           | Why                        |
+| ----------------------------------------------------------- | ------------------------------------------------------------------------------ | -------------------------- |
+| Brand copy, palette, typography, imagery, page composition  | this repo                                                                      | client-local               |
 | Smooth-scroll SPA layout, sticky nav, grain texture         | this repo first → `@bravobyte-org/frontend-core` once a second client needs it | shared-candidate           |
-| FAQ / event-details / RSVP-form / RSVP-submission contracts | `@bravobyte-org/types`                                                    | shared-core, extracted now |
-| Directus integration helpers, site-scoped queries           | this repo first → `bravobyte-data-core` later                             | shared-candidate           |
+| FAQ / event-details / RSVP-form / RSVP-submission contracts | `@bravobyte-org/types`                                                         | shared-core, extracted now |
+| Directus integration helpers, site-scoped queries           | this repo first → `bravobyte-data-core` later                                  | shared-candidate           |
 
 ---
 

--- a/spec.md
+++ b/spec.md
@@ -26,10 +26,15 @@ Resend · Vercel.
 
 **Shared dependencies:**
 
-- `@bravobyte/types` — shared content contracts. Will be added in M1 once the
-  Dolce Vita contracts are extracted and a Phase-1 distribution path is in
-  place (npm workspace at the BravoByte root or a private registry).
-- Future: `@bravobyte/frontend-core`, `@bravobyte/data-core`
+- `@bravobyte-org/types` — shared content contracts (published `1.0.0` to
+  GitHub Packages). Wired in once Dolce Vita's contracts are extracted to
+  the package.
+- `@bravobyte-org/frontend-core` — token-driven Svelte primitives and the
+  first wave of Directus block layouts. The app's `app.css` already maps
+  `--dv-*` brand tokens onto the `--bb-*` contract; the dependency entry
+  and import swaps land alongside the first block migration. See
+  [`bravobyte/.docs/adrs/adr-005-frontend-core-token-contract.md`](../bravobyte/.docs/adrs/adr-005-frontend-core-token-contract.md).
+- Future: `@bravobyte-org/data-core`
 
 ---
 
@@ -48,8 +53,8 @@ configuration. Repo-local rules live in `.cursor/rules/` (when added).
 | Concern                                                     | Repo                                                                      | Why                        |
 | ----------------------------------------------------------- | ------------------------------------------------------------------------- | -------------------------- |
 | Brand copy, palette, typography, imagery, page composition  | this repo                                                                 | client-local               |
-| Smooth-scroll SPA layout, sticky nav, grain texture         | this repo first → `bravobyte-frontend-core` once a second client needs it | shared-candidate           |
-| FAQ / event-details / RSVP-form / RSVP-submission contracts | `bravobyte-types`                                                         | shared-core, extracted now |
+| Smooth-scroll SPA layout, sticky nav, grain texture         | this repo first → `@bravobyte-org/frontend-core` once a second client needs it | shared-candidate           |
+| FAQ / event-details / RSVP-form / RSVP-submission contracts | `@bravobyte-org/types`                                                    | shared-core, extracted now |
 | Directus integration helpers, site-scoped queries           | this repo first → `bravobyte-data-core` later                             | shared-candidate           |
 
 ---
@@ -79,7 +84,7 @@ The homepage is a single Directus `pages` row composed of M2A blocks:
 | --- | ------------------------ | ----------- | ------------------------------------------------------------------ | ---------------------------------------------- |
 | M-1 | GitHub workspace         | done        | —                                                                  | Repo, labels, templates, board, epics, stories |
 | M0  | Foundation               | in progress | [#1](https://github.com/BravoByte-org/dolcevitact-web/milestone/1) | Scaffold + Directus site row + Vercel + DNS    |
-| M1  | Shared content contracts | in review   | [#2](https://github.com/BravoByte-org/dolcevitact-web/milestone/2) | `@bravobyte/types` extension (types PR #2)     |
+| M1  | Shared content contracts | in review   | [#2](https://github.com/BravoByte-org/dolcevitact-web/milestone/2) | `@bravobyte-org/types` extension (types PR #2) |
 | M2  | Directus schema          | in review   | [#3](https://github.com/BravoByte-org/dolcevitact-web/milestone/3) | Idempotent migration script + app plumbing     |
 | M3  | Design system            | done        | [#4](https://github.com/BravoByte-org/dolcevitact-web/milestone/4) | Tokens, decoratives, motion (PR #16 merged)    |
 | M4  | Sections                 | planned     | [#5](https://github.com/BravoByte-org/dolcevitact-web/milestone/5) | 9 sections + nav + footer                      |

--- a/src/app.css
+++ b/src/app.css
@@ -3,11 +3,55 @@
 @import './lib/styles/fonts.css';
 @import './lib/styles/motion.css';
 
+/*
+ * Make `@bravobyte-org/frontend-core` source files visible to Tailwind v4 so
+ * utility classes used inside shared primitives compile into the bundle.
+ */
+@source "../node_modules/@bravobyte-org/frontend-core/src";
+
 /* em-based custom-media for browser zoom + user font-size accessibility. */
 @custom-media --sm (min-width: 40em);
 @custom-media --md (min-width: 48em);
 @custom-media --lg (min-width: 64em);
 @custom-media --xl (min-width: 80em);
+
+/*
+ * BravoByte token contract
+ * ---------------------------------------------------------------
+ * `--bb-*` custom properties are the public API consumed by primitives
+ * shipped from `@bravobyte-org/frontend-core`. Map Dolce's brand tokens
+ * (--dv-*) onto them so shared primitives render in the brand's voice
+ * without importing brand-specific values.
+ *
+ * Canonical mapping table:
+ * `bravobyte/.docs/architecture/bravobyte-frontend-core-tokens.md`
+ */
+:root {
+	--bb-color-primary: var(--dv-color-terracotta-deep);
+	--bb-color-on-primary: #ffffff;
+	--bb-color-fg: var(--dv-color-charcoal);
+	--bb-color-fg-soft: var(--dv-color-charcoal-soft);
+	--bb-color-fg-muted: var(--dv-color-charcoal-mute);
+	--bb-color-surface: color-mix(in srgb, var(--dv-color-ivory) 60%, white 40%);
+	--bb-color-border: color-mix(in srgb, var(--dv-color-sage) 20%, transparent);
+	--bb-color-focus: var(--dv-color-terracotta);
+
+	--bb-radius-md: var(--dv-radius-md);
+	--bb-radius-lg: var(--dv-radius-lg);
+
+	--bb-text-eyebrow: var(--dv-text-eyebrow);
+	--bb-text-h2: var(--dv-text-h2);
+	--bb-text-lede: var(--dv-text-lede);
+	--bb-tracking-eyebrow: var(--dv-tracking-eyebrow);
+
+	--bb-section-padding-x: 1.5rem;
+	--bb-section-padding-y: clamp(3rem, 8vw, 5rem);
+
+	--bb-shadow-soft: var(--dv-shadow-soft);
+	--bb-shadow-card: var(--dv-shadow-card);
+
+	--bb-ease-soft: var(--dv-ease-soft);
+}
 
 /* Map design tokens into Tailwind v4 theme so utilities like bg-ivory,
    text-terracotta, font-display, shadow-soft work. */

--- a/src/app.css
+++ b/src/app.css
@@ -7,7 +7,7 @@
  * Make `@bravobyte-org/frontend-core` source files visible to Tailwind v4 so
  * utility classes used inside shared primitives compile into the bundle.
  */
-@source "../node_modules/@bravobyte-org/frontend-core/src";
+@source '../node_modules/@bravobyte-org/frontend-core/src';
 
 /* em-based custom-media for browser zoom + user font-size accessibility. */
 @custom-media --sm (min-width: 40em);


### PR DESCRIPTION
## Summary

Stages the consumer side for `@bravobyte-org/frontend-core` ahead of the first block-import swap. No imports change in this PR — these are passive wiring additions that let the next PR drop in shared primitives without touching infrastructure.

- **`.npmrc`** — maps the `@bravobyte-org` scope to GitHub Packages with `${NODE_AUTH_TOKEN}` substitution (CI uses `secrets.GITHUB_TOKEN`; locally the developer exports a token with `read:packages`).
- **`src/app.css`** — exposes the `--bb-*` CSS custom property contract, mapped onto Dolce's existing `--dv-*` brand tokens (terracotta-deep / charcoal / sage / ivory) so shared primitives render in the brand's voice without modification.
- **`@source "../node_modules/@bravobyte-org/frontend-core/src"`** — Tailwind v4 content scan so utility classes used inside shared primitives compile into the bundle.
- **`spec.md`** — Shared dependencies section refresh + `@bravobyte-org/*` scope rename in the Rule Zero table and M1 row.

Token contract and rationale: [`bravobyte/.docs/adrs/adr-005-frontend-core-token-contract.md`](https://github.com/BravoByte-org/bravobyte/blob/main/.docs/adrs/adr-005-frontend-core-token-contract.md). Mapping reference: [`bravobyte-frontend-core-tokens.md`](https://github.com/BravoByte-org/bravobyte/blob/main/.docs/architecture/bravobyte-frontend-core-tokens.md).

Companion PR: [BravoByte-org/bravobyte#4](https://github.com/BravoByte-org/bravobyte/pull/4) — the actual primitives and Changesets fragment that bumps `@bravobyte-org/frontend-core` to `1.1.0`.

## Why now (M-1.5 wiring before M6 launch)

M6 (launch) is in progress. This PR adds **passive** infrastructure only — nothing renders differently because no shared primitives are imported yet. The token contract is forward-compatible with everything M6 ships, and lands now so the post-launch primitive integration PR is a single-file diff.

## Test plan

- [x] `app.css` resolves cleanly against `main`
- [x] `spec.md` diff is minimal (`@bravobyte-org/*` rename + Shared dependencies refresh — no milestone status changes)
- [ ] CI green (lint / typecheck / build / Playwright / a11y)
- [ ] After `1.1.0` publishes on `bravobyte`: follow up with a PR that adds `@bravobyte-org/frontend-core` to `dependencies` and swaps one block import (`RichTextBlock` is the simplest candidate) to consume the shared primitive.


Made with [Cursor](https://cursor.com)