### PR TITLE
fix(deploy): pin adapter-vercel runtime to nodejs22.x

### DIFF
--- a/svelte.config.js
+++ b/svelte.config.js
@@ -9,6 +9,13 @@ const config = {
 	},
 	kit: {
 		adapter: vercel({
+			// Pin the deployed serverless runtime so adapter-vercel skips its
+			// `process.version`-based auto-detection. Without this, a Vercel
+			// build runner on a Node version not yet supported by adapter-vercel
+			// (e.g. 24.x) errors with `Unsupported Node.js version` even when
+			// the project's Node setting and `package.json#engines.node` are
+			// pinned to 22. Aligns with `engines.node` in `package.json`.
+			runtime: 'nodejs22.x',
 			images: {
 				sizes: [640, 828, 1200, 1920, 3840],
 				formats: ['image/avif', 'image/webp'],


### PR DESCRIPTION
## Summary

Adds `runtime: 'nodejs22.x'` to the `@sveltejs/adapter-vercel` config so the SvelteKit build skips adapter-vercel's `process.version`-based auto-detection. Belt-and-suspenders against the failure mode that just blocked [starwaytrasporti-web#44](https://github.com/BravoByte-org/starwaytrasporti-web/pull/44).

## Why

`@sveltejs/adapter-vercel@^6.1.1` calls `get_default_runtime()` when no `runtime` option is supplied. That helper inspects `process.version` of the **build environment** to decide which serverless runtime to deploy. If Vercel's build runner is ever on a Node version not yet supported by the adapter (currently 20 and 22), the build fails with:

```
Error: Unsupported Node.js version: vXX.YY.Z. Please use Node 20 or 22 to build your project,
or explicitly specify a runtime in your project's package.json
```

This is what hit Starway's PR #44 deploy: the project's Vercel Node setting was on `Latest`, the build runner picked up Node 24, and adapter-vercel rejected it. Setting the project to `22.x` in the dashboard fixes the immediate failure but leaves the door open every time Vercel bumps its build runtimes ahead of adapter support windows.

Pinning `runtime` in the adapter config short-circuits the auto-detect path entirely, so:

- The build no longer cares what Node version the runner is on (within reason — adapter-vercel still imports modern syntax, but the version check itself is bypassed).
- The deployed function runtime is explicitly `nodejs22.x`, matching `engines.node = "22.x"` in `package.json` and the Vercel project setting.

## Companion PR

- [starwaytrasporti-web#44](https://github.com/BravoByte-org/starwaytrasporti-web/pull/44) — same fix on Starway, stacked onto the existing token-wiring PR since it's what triggered investigating this in the first place.

## Test plan

- [x] `prettier --check svelte.config.js` clean
- [ ] CI green (typecheck / build / unit tests / a11y)
- [ ] Vercel preview deploys successfully on Node 22

## Risk

Very low — the behaviour change is \"the adapter no longer auto-detects\" rather than a runtime change. The deployed function was already running on Node 22 (because Vercel's project setting + \`engines.node\` agree); the only thing this PR changes is *where* that decision is recorded.